### PR TITLE
chore: complete sec overhaul

### DIFF
--- a/apps/admin/src/app/api/proxy/route.ts
+++ b/apps/admin/src/app/api/proxy/route.ts
@@ -2,15 +2,26 @@ import { auth } from "@/auth";
 import { adminFetch } from "@/lib/api";
 import { NextRequest, NextResponse } from "next/server";
 
+function normalizeAdminProxyPath(path: string | null) {
+  if (!path) return null;
+  if (!path.startsWith("/")) return null;
+  if (path.startsWith("//") || path.includes("://")) return null;
+  const segments = path.split("/");
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  return path;
+}
+
 export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const path = req.nextUrl.searchParams.get("path");
+  const path = normalizeAdminProxyPath(req.nextUrl.searchParams.get("path"));
   if (!path) {
-    return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
   }
 
   const res = await adminFetch(`/api/admin${path}`);
@@ -24,9 +35,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const path = req.nextUrl.searchParams.get("path");
+  const path = normalizeAdminProxyPath(req.nextUrl.searchParams.get("path"));
   if (!path) {
-    return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
   }
 
   const body = await req.text();
@@ -45,9 +56,9 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const path = req.nextUrl.searchParams.get("path");
+  const path = normalizeAdminProxyPath(req.nextUrl.searchParams.get("path"));
   if (!path) {
-    return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
   }
 
   const res = await adminFetch(`/api/admin${path}`, { method: "DELETE" });
@@ -61,9 +72,9 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const path = req.nextUrl.searchParams.get("path");
+  const path = normalizeAdminProxyPath(req.nextUrl.searchParams.get("path"));
   if (!path) {
-    return NextResponse.json({ error: "Missing path" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid path" }, { status: 400 });
   }
 
   const body = await req.text();

--- a/apps/admin/src/auth.ts
+++ b/apps/admin/src/auth.ts
@@ -40,12 +40,12 @@ if (isDev && devSecret) {
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers,
   callbacks: {
-    async signIn({ account, profile }) {
+    async signIn({ account }) {
       if (account?.provider === "dev-login") return true;
-      const login = (profile as Record<string, unknown>)?.login;
-      if (typeof login !== "string") return false;
+      const githubId = account?.providerAccountId?.trim();
+      if (!githubId) return false;
       if (ALLOWED_GITHUB_IDS.length === 0) return false;
-      return ALLOWED_GITHUB_IDS.includes(login);
+      return ALLOWED_GITHUB_IDS.includes(githubId);
     },
     async session({ session, token }) {
       if (session.user && token.sub) {

--- a/apps/api/src/__tests__/admin-hardening.test.ts
+++ b/apps/api/src/__tests__/admin-hardening.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+function normalizeAdminProxyPath(path: string | null) {
+  if (!path) return null;
+  if (!path.startsWith("/")) return null;
+  if (path.startsWith("//") || path.includes("://")) return null;
+  const segments = path.split("/");
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  return path;
+}
+
+function canSignInWithGithubId(allowedIds: string[], providerAccountId: string | null | undefined) {
+  const githubId = providerAccountId?.trim();
+  if (!githubId) return false;
+  if (allowedIds.length === 0) return false;
+  return allowedIds.includes(githubId);
+}
+
+describe("admin proxy path normalization", () => {
+  it("accepts normal admin paths", () => {
+    expect(normalizeAdminProxyPath("/bans")).toBe("/bans");
+    expect(normalizeAdminProxyPath("/games/abc123")).toBe("/games/abc123");
+  });
+
+  it("rejects traversal and absolute URL tricks", () => {
+    expect(normalizeAdminProxyPath("../admin")).toBeNull();
+    expect(normalizeAdminProxyPath("/../admin")).toBeNull();
+    expect(normalizeAdminProxyPath("/bans/../../secrets")).toBeNull();
+    expect(normalizeAdminProxyPath("//evil.example/path")).toBeNull();
+    expect(normalizeAdminProxyPath("https://evil.example")).toBeNull();
+    expect(normalizeAdminProxyPath("/https://evil.example")).toBeNull();
+  });
+});
+
+describe("admin GitHub allowlist", () => {
+  it("matches immutable provider account ids", () => {
+    expect(canSignInWithGithubId(["12345"], "12345")).toBe(true);
+    expect(canSignInWithGithubId(["12345"], "99999")).toBe(false);
+  });
+
+  it("does not depend on mutable usernames", () => {
+    const allowedIds = ["12345"];
+    expect(canSignInWithGithubId(allowedIds, "12345")).toBe(true);
+    expect(canSignInWithGithubId(allowedIds, "renamed-user")).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/security-policy.test.ts
+++ b/apps/api/src/__tests__/security-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { authorizeZeroQuery, getZeroMutatorAccessPolicy } from "../security-policy";
+
+describe("authorizeZeroQuery", () => {
+  const unsignedCaller = {
+    proofUserId: null,
+    headerUserId: null,
+    allowUnsigned: false,
+  };
+
+  it("allows public browse queries", async () => {
+    await expect(authorizeZeroQuery("imposter.publicGames", {}, unsignedCaller)).resolves.toBeUndefined();
+    await expect(authorizeZeroQuery("password.publicGames", {}, unsignedCaller)).resolves.toBeUndefined();
+  });
+
+  it("requires proof for self session queries", async () => {
+    await expect(
+      authorizeZeroQuery("sessions.byId", { id: "user-1" }, unsignedCaller)
+    ).rejects.toThrow("Forbidden");
+
+    await expect(
+      authorizeZeroQuery(
+        "sessions.byId",
+        { id: "user-1" },
+        { proofUserId: "user-1", headerUserId: "user-1", allowUnsigned: false }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects unknown query names", async () => {
+    await expect(
+      authorizeZeroQuery("imposter.internalDebug", {}, unsignedCaller)
+    ).rejects.toThrow("Forbidden");
+  });
+});
+
+describe("getZeroMutatorAccessPolicy", () => {
+  it("declares host-only timer and reveal mutators explicitly", () => {
+    expect(getZeroMutatorAccessPolicy("imposter.advanceTimer")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("password.advanceTimer")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("shadeSignal.advanceTimer")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("shadeSignal.reveal")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("locationSignal.advanceTimer")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("locationSignal.revealRound")).toBe("host");
+  });
+
+  it("declares interactive outsider-sensitive mutators explicitly", () => {
+    expect(getZeroMutatorAccessPolicy("chat.send")).toBe("member");
+    expect(getZeroMutatorAccessPolicy("chat.clearForGame")).toBe("host");
+    expect(getZeroMutatorAccessPolicy("locationSignal.submitGuess")).toBe("member");
+    expect(getZeroMutatorAccessPolicy("sessions.setName")).toBe("proof-required");
+  });
+
+  it("keeps demo mutators public and unknown mutators denied", () => {
+    expect(getZeroMutatorAccessPolicy("demo.seedImposter")).toBe("public");
+    expect(getZeroMutatorAccessPolicy("demo.seedLocationSignal")).toBe("public");
+    expect(getZeroMutatorAccessPolicy("demo.unknown")).toBeNull();
+    expect(getZeroMutatorAccessPolicy("notreal.mutator")).toBeNull();
+  });
+});

--- a/apps/api/src/client-info.ts
+++ b/apps/api/src/client-info.ts
@@ -12,6 +12,10 @@ export type ClientInfo = {
 
 const UNKNOWN_IP = "unknown";
 const UNKNOWN_REGION = "unknown";
+const TRUST_PROXY_HEADERS =
+  process.env.TRUST_PROXY_HEADERS === "1"
+  || process.env.TRUST_PROXY_HEADERS === "true"
+  || process.env.NODE_ENV === "test";
 const GEOIP_SUCCESS_TTL_MS = 12 * 60 * 60 * 1000;
 const GEOIP_FAILURE_TTL_MS = 10 * 60 * 1000;
 const GEOIP_TIMEOUT_MS = 2_000;
@@ -185,19 +189,27 @@ async function lookupRegionFromIpApi(ip: string) {
 }
 
 export function extractClientInfo(headers: HeaderReader): ClientInfo {
-  const ip = firstNonEmpty([
-    normalizeIpCandidate(headers.header("cf-connecting-ip")),
-    normalizeIpCandidate(headers.header("x-real-ip")),
-    normalizeIpCandidate(headers.header("x-client-ip")),
-    normalizeIpCandidate(headers.header("x-forwarded-for")),
-    normalizeIpCandidate(headers.header("x-vercel-forwarded-for")),
-  ]);
+  const ip = TRUST_PROXY_HEADERS
+    ? firstNonEmpty([
+        normalizeIpCandidate(headers.header("cf-connecting-ip")),
+        normalizeIpCandidate(headers.header("x-real-ip")),
+        normalizeIpCandidate(headers.header("x-client-ip")),
+        normalizeIpCandidate(headers.header("x-forwarded-for")),
+        normalizeIpCandidate(headers.header("x-vercel-forwarded-for")),
+      ])
+    : "";
 
   return {
     ip: ip || UNKNOWN_IP,
-    region: sanitizeRegion(firstNonEmpty([headers.header("cf-ipcountry"), headers.header("x-vercel-ip-country")])),
+    region: sanitizeRegion(
+      TRUST_PROXY_HEADERS ? firstNonEmpty([headers.header("cf-ipcountry"), headers.header("x-vercel-ip-country")]) : undefined
+    ),
     userAgent: sanitizeUserAgent(headers.header("user-agent")),
   };
+}
+
+export function extractClientIp(headers: HeaderReader): string {
+  return extractClientInfo(headers).ip;
 }
 
 export async function resolveRegionForIp(ip: string, fallbackRegion = UNKNOWN_REGION) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,5 @@
 import { fallbackPlayerName, mutators, queries, schema } from "@games/shared";
-import { adminNameOverrides, chatMessages, chainReactionGames, decryptSecret, encryptSecret, gameEncryptionKeys, generateGameKey, imposterGames, isEncrypted, locationSignalGames, passwordGames, pipsBannedSessions, pipsScores, sessions, shadeSignalGames, shikakuScores, shikakuBannedSessions, statusTable } from "@games/shared";
+import { adminNameOverrides, chatMessages, chainReactionGames, encryptSecret, gameEncryptionKeys, generateGameKey, imposterGames, isEncrypted, locationSignalGames, passwordGames, pipsBannedSessions, pipsScores, sessions, shadeSignalGames, shikakuScores, shikakuBannedSessions, statusTable } from "@games/shared";
 
 import { handleMutateRequest, handleQueryRequest } from "@rocicorp/zero/server";
 import { mustGetMutator, mustGetQuery } from "@rocicorp/zero";
@@ -13,6 +13,7 @@ import { pusher, getCustomStatus, setBanChecker, getBanChecker } from "./broadca
 import { adminRoutes, isBanned, getRestrictedNamesRoute, loadPersistedStatus } from "./admin-routes";
 import { allowUnrestrictedSessionName, findRestrictedNameMatch } from "./name-rules";
 import { rateLimiter } from "./rate-limit";
+import { authorizeZeroQuery, getZeroMutatorAccessPolicy, resolveGameSecretAccess, type GameType } from "./security-policy";
 import {
   chooseCanonicalSession,
   createSignedSessionCookieValue,
@@ -34,27 +35,72 @@ import { embedRoutes } from "./embed-routes";
 config({ path: "../../.env" });
 
 const app = new Hono();
+const DEFAULT_WEB_ORIGIN = "https://games.lawsonhart.me";
 const DB_STATUS_KEY = process.env.DB_STATUS_KEY?.trim() || "footer";
 const DB_STATUS_EXPECTED_VALUE = process.env.DB_STATUS_EXPECTED_VALUE?.trim() || "ok";
-const SESSION_COOKIE_SECRET = process.env.SESSION_COOKIE_SECRET?.trim() || process.env.PUSHER_SECRET?.trim() || "games-dev-session-secret";
 const DEV_MODE = process.env.NODE_ENV !== "production";
+const SESSION_COOKIE_SECRET = process.env.SESSION_COOKIE_SECRET?.trim() || (DEV_MODE ? "games-dev-session-secret" : "");
+const CLEANUP_SECRET = process.env.CLEANUP_SECRET?.trim() || (DEV_MODE ? "cleanup-local" : "");
+const ALLOWED_WEB_ORIGINS = (process.env.ALLOWED_WEB_ORIGINS?.trim() || DEFAULT_WEB_ORIGIN)
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const REQUIRED_ZERO_TABLES = [
+  "imposter_public_games",
+] as const;
+if (!DEV_MODE) {
+  if (!SESSION_COOKIE_SECRET) {
+    throw new Error("SESSION_COOKIE_SECRET is required in production");
+  }
+  if (!CLEANUP_SECRET) {
+    throw new Error("CLEANUP_SECRET is required in production");
+  }
+}
 if (DEV_MODE) {
   console.log("[dev-mode] Security relaxations active — fingerprint binding, session proof, and rate limits are loosened for local testing.");
+}
+
+async function assertRequiredZeroTables() {
+  const requiredTableLiterals = sql.join(
+    REQUIRED_ZERO_TABLES.map((tableName) => sql`${tableName}`),
+    sql`, `
+  );
+  const result = await drizzleClient.execute(sql`
+    select table_name
+    from information_schema.tables
+    where table_schema = 'public'
+      and table_name in (${requiredTableLiterals})
+  `);
+  const rows = Array.isArray(result)
+    ? result
+    : (result.rows ?? []);
+  const found = new Set(
+    rows
+      .map((row: any) => row?.table_name)
+      .filter((value: unknown): value is string => typeof value === "string")
+  );
+  const missing = REQUIRED_ZERO_TABLES.filter((tableName) => !found.has(tableName));
+  if (missing.length === 0) {
+    return;
+  }
+
+  const message = `Missing required Zero sync tables: ${missing.join(", ")}. Run \`bun db:push\` before starting sync clients.`;
+  if (DEV_MODE) {
+    console.warn(`[startup] ${message}`);
+    return;
+  }
+  throw new Error(message);
 }
 
 app.use(
   "*",
   cors({
     origin: (origin) => {
-      if (!origin) return "https://games.lawsonhart.me";
-      if (
-        origin.endsWith(".lawsonhart.me") ||
-        origin === "https://games.lawsonhart.me" ||
-        origin.startsWith("http://localhost:")
-      ) {
+      if (!origin) return DEFAULT_WEB_ORIGIN;
+      if (ALLOWED_WEB_ORIGINS.includes(origin) || origin.startsWith("http://localhost:") || origin.startsWith("http://127.0.0.1:")) {
         return origin;
       }
-      return "https://games.lawsonhart.me";
+      return DEFAULT_WEB_ORIGIN;
     },
     allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization", "x-zero-user-id", ZERO_SESSION_PROOF_HEADER],
@@ -386,8 +432,13 @@ app.post("/api/pusher/auth", async (c) => {
     return c.json({ error: "Missing socket_id or channel_name" }, 400);
   }
 
+  const verifiedClaimedSessionId = getVerifiedClaimedSessionId(c, claimedSessionId);
+  if (!verifiedClaimedSessionId) {
+    return c.json({ error: "Invalid session proof" }, 403);
+  }
+
   const resolvedIdentity = await resolveSessionIdentity(c, {
-    claimedSessionId,
+    claimedSessionId: verifiedClaimedSessionId,
     allowCreate: false,
   });
 
@@ -419,6 +470,8 @@ app.post("/api/pusher/auth", async (c) => {
     if (channelSessionId !== sessionId) {
       return c.json({ error: "Unauthorized channel" }, 403);
     }
+  } else if (channelName !== "games-broadcast") {
+    return c.json({ error: "Unauthorized channel" }, 403);
   }
 
   const authResponse = pusher.authorizeChannel(socketId, channelName);
@@ -464,8 +517,13 @@ app.post("/api/presence/heartbeat", async (c) => {
     return c.json({ error: "sessionId required" }, 400);
   }
 
+  const verifiedClaimedSessionId = getVerifiedClaimedSessionId(c, claimedSessionId);
+  if (!verifiedClaimedSessionId) {
+    return c.json({ error: "Invalid session proof" }, 403);
+  }
+
   const resolvedIdentity = await resolveSessionIdentity(c, {
-    claimedSessionId,
+    claimedSessionId: verifiedClaimedSessionId,
     allowCreate: false,
   });
 
@@ -549,12 +607,15 @@ function getVerifiedClaimedSessionId(
   const proofUserId = getCallerProofUserId(c);
   const normalizedClaimedId = normalizeSessionId(claimedSessionId);
 
-  // In dev mode, trust claimed session IDs without proof verification
   if (DEV_MODE) {
     return proofUserId ?? normalizedClaimedId;
   }
 
-  if (headerUserId !== "anon" && (!proofUserId || headerUserId !== proofUserId)) {
+  if (!proofUserId) {
+    return null;
+  }
+
+  if (headerUserId !== "anon" && headerUserId !== proofUserId) {
     return null;
   }
 
@@ -562,7 +623,7 @@ function getVerifiedClaimedSessionId(
     return null;
   }
 
-  return proofUserId ?? normalizedClaimedId;
+  return proofUserId;
 }
 
 const MAX_ID_LEN = 64;
@@ -583,23 +644,6 @@ function assertCallerValue(userId: string, claimed: unknown, field: string) {
   if (claimed !== userId) {
     throw new Error("Not allowed");
   }
-}
-
-function requiresMutatorSessionProof(name: string, args: unknown) {
-  if (name.startsWith("demo.") && process.env.NODE_ENV !== "production") {
-    return false;
-  }
-  if (args == null || typeof args !== "object") {
-    return false;
-  }
-
-  const payload = args as Record<string, unknown>;
-  const [namespace] = name.split(".");
-  return namespace === "sessions"
-    || "sessionId" in payload
-    || "hostId" in payload
-    || "senderId" in payload
-    || "voterId" in payload;
 }
 
 function applyCanonicalMutatorCaller<T>(userId: string, name: string, args: T): T {
@@ -632,7 +676,11 @@ function applyCanonicalMutatorCaller<T>(userId: string, name: string, args: T): 
 }
 
 function resolveZeroMutatorCaller(userId: string, name: string, args: unknown, proofUserId: string | null) {
-  if (!requiresMutatorSessionProof(name, args)) {
+  const accessPolicy = getZeroMutatorAccessPolicy(name);
+  if (!accessPolicy || accessPolicy === "system") {
+    throw new Error("Forbidden");
+  }
+  if (accessPolicy === "public") {
     return proofUserId ?? userId;
   }
   if (!proofUserId) {
@@ -711,8 +759,6 @@ async function assertAllowedSessionNameMutation(name: string, args: unknown) {
   }
 }
 
-type GameType = "imposter" | "password" | "chain_reaction" | "shade_signal" | "location_signal";
-
 function normalizeGameType(value: unknown): GameType | null {
   if (
     value === "imposter" ||
@@ -724,83 +770,6 @@ function normalizeGameType(value: unknown): GameType | null {
     return value;
   }
   return null;
-}
-
-async function canAccessGameSecret(gameType: GameType, gameId: string, sessionId: string) {
-  if (gameType === "imposter") {
-    const [game] = await drizzleClient
-      .select({ phase: imposterGames.phase, players: imposterGames.players })
-      .from(imposterGames)
-      .where(eq(imposterGames.id, gameId));
-    if (!game) return { allowed: false, reason: "Game not found", status: 404 as const };
-    const me = game.players.find((p) => p.sessionId === sessionId);
-    if (!me) return { allowed: false, reason: "Forbidden", status: 403 as const };
-    const revealPhase = game.phase === "results" || game.phase === "finished" || game.phase === "ended";
-    if (!revealPhase && game.phase !== "playing" && game.phase !== "voting") {
-      return { allowed: false, reason: "Forbidden", status: 403 as const };
-    }
-    if (!revealPhase && me.role === "imposter") {
-      return { allowed: false, reason: "Forbidden", status: 403 as const };
-    }
-    return { allowed: true, myRole: me.role ?? "player" };
-  }
-
-  if (gameType === "password") {
-    const [game] = await drizzleClient
-      .select({ phase: passwordGames.phase, teams: passwordGames.teams, activeRounds: passwordGames.activeRounds })
-      .from(passwordGames)
-      .where(eq(passwordGames.id, gameId));
-    if (!game) return { allowed: false, reason: "Game not found", status: 404 as const };
-    const team = game.teams.find((t) => t.members.includes(sessionId));
-    if (!team) return { allowed: false, reason: "Forbidden", status: 403 as const };
-    const inActiveRound = game.phase === "playing";
-    if (inActiveRound) {
-      const isGuesser = game.activeRounds.some((round) => round.guesserId === sessionId);
-      if (isGuesser) {
-        return { allowed: false, reason: "Forbidden", status: 403 as const };
-      }
-    }
-    return { allowed: true, myRole: "player" as const };
-  }
-
-  if (gameType === "shade_signal") {
-    const [game] = await drizzleClient
-      .select({ phase: shadeSignalGames.phase, leaderId: shadeSignalGames.leaderId, players: shadeSignalGames.players })
-      .from(shadeSignalGames)
-      .where(eq(shadeSignalGames.id, gameId));
-    if (!game) return { allowed: false, reason: "Game not found", status: 404 as const };
-    const isPlayer = game.players.some((p) => p.sessionId === sessionId);
-    if (!isPlayer) return { allowed: false, reason: "Forbidden", status: 403 as const };
-    const revealPhase = game.phase === "reveal" || game.phase === "finished" || game.phase === "ended";
-    if (!revealPhase && game.leaderId !== sessionId) {
-      return { allowed: false, reason: "Forbidden", status: 403 as const };
-    }
-    return { allowed: true, myRole: game.leaderId === sessionId ? "leader" : "player" };
-  }
-
-  if (gameType === "location_signal") {
-    const [game] = await drizzleClient
-      .select({ phase: locationSignalGames.phase, leaderId: locationSignalGames.leaderId, players: locationSignalGames.players })
-      .from(locationSignalGames)
-      .where(eq(locationSignalGames.id, gameId));
-    if (!game) return { allowed: false, reason: "Game not found", status: 404 as const };
-    const isPlayer = game.players.some((p) => p.sessionId === sessionId);
-    if (!isPlayer) return { allowed: false, reason: "Forbidden", status: 403 as const };
-    const revealPhase = game.phase === "reveal" || game.phase === "finished" || game.phase === "ended";
-    if (!revealPhase && game.leaderId !== sessionId) {
-      return { allowed: false, reason: "Forbidden", status: 403 as const };
-    }
-    return { allowed: true, myRole: game.leaderId === sessionId ? "leader" : "player" };
-  }
-
-  const [game] = await drizzleClient
-    .select({ phase: chainReactionGames.phase, players: chainReactionGames.players })
-    .from(chainReactionGames)
-    .where(eq(chainReactionGames.id, gameId));
-  if (!game) return { allowed: false, reason: "Game not found", status: 404 as const };
-  const isPlayer = game.players.some((p) => p.sessionId === sessionId);
-  if (!isPlayer) return { allowed: false, reason: "Forbidden", status: 403 as const };
-  return { allowed: true, myRole: "player" as const };
 }
 
 async function getOrCreateGameKey(gameType: GameType, gameId: string) {
@@ -940,91 +909,6 @@ app.post("/api/game-secret/init", async (c) => {
   return c.json({ ok: true });
 });
 
-app.post("/api/game-secret/pre-reveal", async (c) => {
-  const body = await c.req.json().catch(() => null) as {
-    gameType?: unknown;
-    gameId?: unknown;
-    sessionId?: unknown;
-  } | null;
-
-  const gameType = normalizeGameType(body?.gameType);
-  const gameId = validId(body?.gameId);
-  const claimedSessionId = validId(body?.sessionId);
-  if (!gameType || !gameId || !claimedSessionId) {
-    return c.json({ error: "gameType, gameId, sessionId required" }, 400);
-  }
-
-  const verifiedClaimedSessionId = getVerifiedClaimedSessionId(c, claimedSessionId);
-  if (!verifiedClaimedSessionId) {
-    return c.json({ error: "Forbidden" }, 403);
-  }
-
-  const resolvedIdentity = await resolveSessionIdentity(c, {
-    claimedSessionId: verifiedClaimedSessionId,
-    allowCreate: false,
-  });
-  if (!resolvedIdentity) {
-    return c.json({ error: "Invalid session" }, 403);
-  }
-  const sessionId = resolvedIdentity.sessionId;
-
-  if (gameType !== "shade_signal" && gameType !== "location_signal") {
-    return c.json({ error: "Unsupported gameType" }, 400);
-  }
-
-  if (gameType === "shade_signal") {
-    const [game] = await drizzleClient
-      .select({ hostId: shadeSignalGames.hostId, encryptedTarget: shadeSignalGames.encryptedTarget })
-      .from(shadeSignalGames)
-      .where(eq(shadeSignalGames.id, gameId))
-      .limit(1);
-    if (!game) return c.json({ error: "Game not found" }, 404);
-    if (game.hostId !== sessionId) return c.json({ error: "Forbidden" }, 403);
-    if (!game.encryptedTarget) return c.json({ ok: true, alreadyPlain: true });
-
-    const key = await getOrCreateGameKey(gameType, gameId);
-    const decrypted = await decryptSecret(game.encryptedTarget, key);
-    let payload: { row: number; col: number };
-    try {
-      const parsed = JSON.parse(decrypted);
-      if (typeof parsed?.row !== "number" || typeof parsed?.col !== "number") throw new Error("bad payload");
-      payload = parsed;
-    } catch {
-      return c.json({ error: "Corrupted encrypted target" }, 500);
-    }
-    await drizzleClient
-      .update(shadeSignalGames)
-      .set({ targetRow: payload.row, targetCol: payload.col, encryptedTarget: null, updatedAt: Date.now() })
-      .where(eq(shadeSignalGames.id, gameId));
-    return c.json({ ok: true });
-  }
-
-  const [game] = await drizzleClient
-    .select({ hostId: locationSignalGames.hostId, encryptedTarget: locationSignalGames.encryptedTarget })
-    .from(locationSignalGames)
-    .where(eq(locationSignalGames.id, gameId))
-    .limit(1);
-  if (!game) return c.json({ error: "Game not found" }, 404);
-  if (game.hostId !== sessionId) return c.json({ error: "Forbidden" }, 403);
-  if (!game.encryptedTarget) return c.json({ ok: true, alreadyPlain: true });
-
-  const key = await getOrCreateGameKey(gameType, gameId);
-  const decrypted = await decryptSecret(game.encryptedTarget, key);
-  let payload: { lat: number; lng: number };
-  try {
-    const parsed = JSON.parse(decrypted);
-    if (typeof parsed?.lat !== "number" || typeof parsed?.lng !== "number") throw new Error("bad payload");
-    payload = parsed;
-  } catch {
-    return c.json({ error: "Corrupted encrypted target" }, 500);
-  }
-  await drizzleClient
-    .update(locationSignalGames)
-    .set({ targetLat: payload.lat, targetLng: payload.lng, encryptedTarget: null, updatedAt: Date.now() })
-    .where(eq(locationSignalGames.id, gameId));
-  return c.json({ ok: true });
-});
-
 app.post("/api/game-secret/key", async (c) => {
   const body = await c.req.json().catch(() => null) as {
     gameType?: unknown;
@@ -1053,14 +937,14 @@ app.post("/api/game-secret/key", async (c) => {
   }
   const sessionId = resolvedIdentity.sessionId;
 
-  const access = await canAccessGameSecret(gameType, gameId, sessionId);
+  const access = await resolveGameSecretAccess(gameType, gameId, sessionId);
   if (!access.allowed) {
     return c.json({ error: access.reason }, access.status);
   }
 
-  const key = await getOrCreateGameKey(gameType, gameId);
+  const key = access.keyAllowed ? await getOrCreateGameKey(gameType, gameId) : null;
 
-  return c.json({ ok: true, key, myRole: access.myRole ?? null });
+  return c.json({ ok: true, key, myRole: access.myRole, scopes: access.scopes });
 });
 
 function detectPlatform() {
@@ -2337,12 +2221,20 @@ app.get("/debug/build-info", async (c) => {
 
 app.post("/api/zero/query", async (c) => {
   const request = c.req.raw;
-  const callerUserId = getCallerProofUserId(c) ?? getCallerUserId(c);
+  const proofUserId = getCallerProofUserId(c);
+  const headerUserId = getCallerUserId(c);
+  const callerUserId = proofUserId ?? headerUserId;
+  const queryHandler = (async (name: string, args: unknown) => {
+    await authorizeZeroQuery(name, args, {
+      proofUserId,
+      headerUserId: headerUserId === "anon" ? null : headerUserId,
+      allowUnsigned: DEV_MODE,
+    });
+    const query = mustGetQuery(queries, name);
+    return query.fn({ args: args as any, ctx: { userId: callerUserId } });
+  }) as any;
   const result = await handleQueryRequest({
-    handler: (name, args) => {
-      const query = mustGetQuery(queries, name);
-      return query.fn({ args, ctx: { userId: callerUserId } });
-    },
+    handler: queryHandler,
     schema,
     request,
     userID: callerUserId,
@@ -2789,11 +2681,68 @@ async function runActivityReport() {
   return lines.join("\n");
 }
 
+app.get("/api/public-games", async (c) => {
+  const imposterRows = await drizzleClient.select().from(imposterGames).where(and(eq(imposterGames.isPublic, true), ne(imposterGames.phase, "ended")));
+  const passwordRows = await drizzleClient.select().from(passwordGames).where(and(eq(passwordGames.isPublic, true), ne(passwordGames.phase, "ended")));
+  const chainRows = await drizzleClient.select().from(chainReactionGames).where(and(eq(chainReactionGames.isPublic, true), ne(chainReactionGames.phase, "ended"), ne(chainReactionGames.phase, "finished")));
+  const shadeRows = await drizzleClient.select().from(shadeSignalGames).where(and(eq(shadeSignalGames.isPublic, true), ne(shadeSignalGames.phase, "ended")));
+  const locationRows = await drizzleClient.select().from(locationSignalGames).where(and(eq(locationSignalGames.isPublic, true), ne(locationSignalGames.phase, "ended")));
+
+  const payload = {
+    imposter: imposterRows.map((game) => ({
+      id: game.id,
+      code: game.code,
+      phase: game.phase,
+      hostName: game.players.find((player) => player.sessionId === game.hostId)?.name ?? null,
+      playerCount: game.players.length,
+      spectatorCount: game.spectators.length,
+      createdAt: game.createdAt,
+    })),
+    password: passwordRows.map((game) => ({
+      id: game.id,
+      code: game.code,
+      phase: game.phase,
+      hostName: null,
+      playerCount: game.teams.reduce((total, team) => total + team.members.length, 0),
+      spectatorCount: game.spectators.length,
+      createdAt: game.createdAt,
+    })),
+    chain_reaction: chainRows.map((game) => ({
+      id: game.id,
+      code: game.code,
+      phase: game.phase,
+      hostName: game.players.find((player) => player.sessionId === game.hostId)?.name ?? null,
+      playerCount: game.players.length,
+      spectatorCount: game.spectators.length,
+      createdAt: game.createdAt,
+    })),
+    shade_signal: shadeRows.map((game) => ({
+      id: game.id,
+      code: game.code,
+      phase: game.phase,
+      hostName: game.players.find((player) => player.sessionId === game.hostId)?.name ?? null,
+      playerCount: game.players.length,
+      spectatorCount: game.spectators.length,
+      createdAt: game.createdAt,
+    })),
+    location_signal: locationRows.map((game) => ({
+      id: game.id,
+      code: game.code,
+      phase: game.phase,
+      hostName: game.players.find((player) => player.sessionId === game.hostId)?.name ?? null,
+      playerCount: game.players.length,
+      spectatorCount: game.spectators.length,
+      createdAt: game.createdAt,
+    })),
+  };
+
+  return c.json(payload);
+});
+
 // Accept both GET and POST so any cron service works
 app.on(["GET", "POST"], "/api/cleanup", async (c) => {
   const authHeader = c.req.header("Authorization");
-  const expectedToken = process.env.CLEANUP_SECRET ?? "cleanup-local";
-  if (authHeader !== `Bearer ${expectedToken}`) {
+  if (authHeader !== `Bearer ${CLEANUP_SECRET}`) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
@@ -2805,8 +2754,7 @@ app.on(["GET", "POST"], "/api/cleanup", async (c) => {
 // Activity report endpoint (same auth as cleanup)
 app.on(["GET", "POST"], "/api/activity", async (c) => {
   const authHeader = c.req.header("Authorization");
-  const expectedToken = process.env.CLEANUP_SECRET ?? "cleanup-local";
-  if (authHeader !== `Bearer ${expectedToken}`) {
+  if (authHeader !== `Bearer ${CLEANUP_SECRET}`) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
@@ -2816,6 +2764,7 @@ app.on(["GET", "POST"], "/api/activity", async (c) => {
 });
 
 const port = Number(process.env.PORT ?? process.env.API_PORT ?? 3001);
+await assertRequiredZeroTables();
 const server = Bun.serve({
   fetch: app.fetch,
   port,

--- a/apps/api/src/rate-limit.ts
+++ b/apps/api/src/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from "hono";
+import { extractClientIp } from "./client-info";
 
 interface RateLimitOptions {
   windowMs: number;
@@ -24,9 +25,8 @@ setInterval(() => {
 }, 5 * 60_000).unref();
 
 function getClientIP(c: { req: { header: (name: string) => string | undefined } }): string {
-  const raw = c.req.header("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  // Cap length to prevent memory abuse from spoofed headers
-  return raw.length <= 45 ? raw : raw.slice(0, 45);
+  const ip = extractClientIp(c.req);
+  return ip.length <= 45 ? ip : ip.slice(0, 45);
 }
 
 export function rateLimiter(options: RateLimitOptions): MiddlewareHandler {
@@ -60,10 +60,18 @@ export function rateLimiter(options: RateLimitOptions): MiddlewareHandler {
       );
     }
 
-    // Prevent unbounded memory growth from many unique IPs
+    // Fail closed once the limiter reaches capacity instead of silently
+    // skipping limits for newly-spoofed identities.
     if (!store.has(bucketKey) && store.size >= MAX_BUCKETS) {
-      await next();
-      return;
+      return c.json(
+        {
+          error: "Too many requests",
+          code: "RATE_LIMIT_CAPACITY",
+          message: "Rate limiter capacity reached. Please retry shortly.",
+          scope,
+        },
+        429
+      );
     }
 
     timestamps.push(now);

--- a/apps/api/src/security-policy.ts
+++ b/apps/api/src/security-policy.ts
@@ -1,0 +1,671 @@
+import {
+  chainReactionGames,
+  imposterGames,
+  locationSignalGames,
+  passwordGames,
+  shadeSignalGames,
+} from "@games/shared";
+import { eq } from "drizzle-orm";
+import { drizzleClient } from "./db-provider";
+
+export type GameType =
+  | "imposter"
+  | "password"
+  | "chain_reaction"
+  | "shade_signal"
+  | "location_signal";
+
+export type SurfaceAccess =
+  | "public"
+  | "proof-required"
+  | "member"
+  | "host"
+  | "leader"
+  | "admin"
+  | "system";
+
+const ZERO_MUTATOR_POLICIES = new Map<string, SurfaceAccess>([
+  ...[
+    "sessions.upsert",
+    "sessions.setName",
+    "sessions.attachGame",
+    "sessions.clearGame",
+    "sessions.touchPresence",
+  ].map((name) => [name, "proof-required"] as const),
+  ...[
+    "imposter.create",
+    "imposter.join",
+    "imposter.leave",
+    "imposter.start",
+    "imposter.submitClue",
+    "imposter.submitVote",
+    "imposter.nextRound",
+    "imposter.resetToLobby",
+    "imposter.announce",
+    "imposter.kick",
+    "imposter.endGame",
+    "imposter.joinAsSpectator",
+    "imposter.leaveSpectator",
+    "imposter.removeSpectator",
+    "imposter.voteSkipResults",
+    "imposter.setPublic",
+  ].map((name) => [name, "proof-required"] as const),
+  ["imposter.advanceTimer", "host"],
+  ...[
+    "password.create",
+    "password.join",
+    "password.leave",
+    "password.start",
+    "password.submitClue",
+    "password.submitGuess",
+    "password.skipWord",
+    "password.switchTeam",
+    "password.movePlayer",
+    "password.lockTeams",
+    "password.resetToLobby",
+    "password.announce",
+    "password.kick",
+    "password.endGame",
+    "password.joinAsSpectator",
+    "password.leaveSpectator",
+    "password.removeSpectator",
+    "password.setPublic",
+  ].map((name) => [name, "proof-required"] as const),
+  ["password.advanceTimer", "host"],
+  ...[
+    "chainReaction.create",
+    "chainReaction.join",
+    "chainReaction.leave",
+    "chainReaction.updateSettings",
+    "chainReaction.kick",
+    "chainReaction.start",
+    "chainReaction.submitChain",
+    "chainReaction.revealLetter",
+    "chainReaction.guess",
+    "chainReaction.giveUp",
+    "chainReaction.resetToLobby",
+    "chainReaction.endGame",
+    "chainReaction.joinAsSpectator",
+    "chainReaction.leaveSpectator",
+    "chainReaction.announce",
+    "chainReaction.removeSpectator",
+    "chainReaction.setPublic",
+  ].map((name) => [name, "proof-required"] as const),
+  ...[
+    "shadeSignal.create",
+    "shadeSignal.join",
+    "shadeSignal.leave",
+    "shadeSignal.kick",
+    "shadeSignal.announce",
+    "shadeSignal.updateSettings",
+    "shadeSignal.start",
+    "shadeSignal.setTarget",
+    "shadeSignal.submitClue",
+    "shadeSignal.submitGuess",
+    "shadeSignal.nextRound",
+    "shadeSignal.resetToLobby",
+    "shadeSignal.endGame",
+    "shadeSignal.joinAsSpectator",
+    "shadeSignal.leaveSpectator",
+    "shadeSignal.removeSpectator",
+    "shadeSignal.setPublic",
+  ].map((name) => [name, "proof-required"] as const),
+  ["shadeSignal.advanceTimer", "host"],
+  ["shadeSignal.reveal", "host"],
+  ...[
+    "locationSignal.create",
+    "locationSignal.join",
+    "locationSignal.leave",
+    "locationSignal.start",
+    "locationSignal.setTarget",
+    "locationSignal.submitClue",
+    "locationSignal.nextRound",
+    "locationSignal.kick",
+    "locationSignal.announce",
+    "locationSignal.endGame",
+    "locationSignal.joinAsSpectator",
+    "locationSignal.leaveSpectator",
+    "locationSignal.removeSpectator",
+    "locationSignal.resetToLobby",
+    "locationSignal.setPublic",
+  ].map((name) => [name, "proof-required"] as const),
+  ["locationSignal.submitGuess", "member"],
+  ["locationSignal.revealRound", "host"],
+  ["locationSignal.advanceTimer", "host"],
+  ["chat.send", "member"],
+  ["chat.clearForGame", "host"],
+  ...[
+    "demo.seedImposter",
+    "demo.seedPassword",
+    "demo.seedChainReaction",
+    "demo.seedShadeSignal",
+    "demo.seedLocationSignal",
+  ].map((name) => [name, "public"] as const),
+]);
+
+export function getZeroMutatorAccessPolicy(name: string): SurfaceAccess | null {
+  return ZERO_MUTATOR_POLICIES.get(name) ?? null;
+}
+
+type QueryCaller = {
+  proofUserId: string | null;
+  headerUserId: string | null;
+  allowUnsigned: boolean;
+};
+
+type SecretAccess = {
+  allowed: boolean;
+  status: 200 | 403 | 404;
+  reason?: string;
+  keyAllowed: boolean;
+  myRole: string | null;
+  scopes: string[];
+};
+
+type GameAccess = {
+  isPublic: boolean;
+  isMember: boolean;
+  isHost: boolean;
+  isLeader: boolean;
+  isSpectator: boolean;
+};
+
+function getCallerUserId(caller: QueryCaller) {
+  return caller.proofUserId ?? (caller.allowUnsigned ? caller.headerUserId : null);
+}
+
+function isDummyLookup(value: string | undefined) {
+  return value === "__none__" || value === "______";
+}
+
+async function getAccessByGameId(gameType: GameType, gameId: string, sessionId: string | null): Promise<GameAccess | null> {
+  if (gameType === "imposter") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: imposterGames.isPublic,
+        hostId: imposterGames.hostId,
+        players: imposterGames.players,
+        spectators: imposterGames.spectators,
+      })
+      .from(imposterGames)
+      .where(eq(imposterGames.id, gameId))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "password") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: passwordGames.isPublic,
+        hostId: passwordGames.hostId,
+        teams: passwordGames.teams,
+        spectators: passwordGames.spectators,
+      })
+      .from(passwordGames)
+      .where(eq(passwordGames.id, gameId))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.teams.some((team) => team.members.includes(sessionId))),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "chain_reaction") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: chainReactionGames.isPublic,
+        hostId: chainReactionGames.hostId,
+        players: chainReactionGames.players,
+        spectators: chainReactionGames.spectators,
+      })
+      .from(chainReactionGames)
+      .where(eq(chainReactionGames.id, gameId))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "shade_signal") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: shadeSignalGames.isPublic,
+        hostId: shadeSignalGames.hostId,
+        leaderId: shadeSignalGames.leaderId,
+        players: shadeSignalGames.players,
+        spectators: shadeSignalGames.spectators,
+      })
+      .from(shadeSignalGames)
+      .where(eq(shadeSignalGames.id, gameId))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: Boolean(sessionId && game.leaderId === sessionId),
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  const [game] = await drizzleClient
+    .select({
+      isPublic: locationSignalGames.isPublic,
+      hostId: locationSignalGames.hostId,
+      leaderId: locationSignalGames.leaderId,
+      players: locationSignalGames.players,
+      spectators: locationSignalGames.spectators,
+    })
+    .from(locationSignalGames)
+    .where(eq(locationSignalGames.id, gameId))
+    .limit(1);
+  if (!game) return null;
+  return {
+    isPublic: game.isPublic,
+    isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+    isHost: Boolean(sessionId && game.hostId === sessionId),
+    isLeader: Boolean(sessionId && game.leaderId === sessionId),
+    isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+  };
+}
+
+async function getAccessByCode(gameType: GameType, code: string, sessionId: string | null): Promise<GameAccess | null> {
+  if (gameType === "imposter") {
+    const [game] = await drizzleClient
+      .select({
+        id: imposterGames.id,
+        isPublic: imposterGames.isPublic,
+        hostId: imposterGames.hostId,
+        players: imposterGames.players,
+        spectators: imposterGames.spectators,
+      })
+      .from(imposterGames)
+      .where(eq(imposterGames.code, code))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "password") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: passwordGames.isPublic,
+        hostId: passwordGames.hostId,
+        teams: passwordGames.teams,
+        spectators: passwordGames.spectators,
+      })
+      .from(passwordGames)
+      .where(eq(passwordGames.code, code))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.teams.some((team) => team.members.includes(sessionId))),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "chain_reaction") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: chainReactionGames.isPublic,
+        hostId: chainReactionGames.hostId,
+        players: chainReactionGames.players,
+        spectators: chainReactionGames.spectators,
+      })
+      .from(chainReactionGames)
+      .where(eq(chainReactionGames.code, code))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: false,
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  if (gameType === "shade_signal") {
+    const [game] = await drizzleClient
+      .select({
+        isPublic: shadeSignalGames.isPublic,
+        hostId: shadeSignalGames.hostId,
+        leaderId: shadeSignalGames.leaderId,
+        players: shadeSignalGames.players,
+        spectators: shadeSignalGames.spectators,
+      })
+      .from(shadeSignalGames)
+      .where(eq(shadeSignalGames.code, code))
+      .limit(1);
+    if (!game) return null;
+    return {
+      isPublic: game.isPublic,
+      isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+      isHost: Boolean(sessionId && game.hostId === sessionId),
+      isLeader: Boolean(sessionId && game.leaderId === sessionId),
+      isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+    };
+  }
+
+  const [game] = await drizzleClient
+    .select({
+      isPublic: locationSignalGames.isPublic,
+      hostId: locationSignalGames.hostId,
+      leaderId: locationSignalGames.leaderId,
+      players: locationSignalGames.players,
+      spectators: locationSignalGames.spectators,
+    })
+    .from(locationSignalGames)
+    .where(eq(locationSignalGames.code, code))
+    .limit(1);
+  if (!game) return null;
+  return {
+    isPublic: game.isPublic,
+    isMember: Boolean(sessionId && game.players.some((player) => player.sessionId === sessionId)),
+    isHost: Boolean(sessionId && game.hostId === sessionId),
+    isLeader: Boolean(sessionId && game.leaderId === sessionId),
+    isSpectator: Boolean(sessionId && game.spectators.some((spectator) => spectator.sessionId === sessionId)),
+  };
+}
+
+function requireProofUserId(caller: QueryCaller) {
+  return caller.proofUserId ?? null;
+}
+
+async function assertMemberOrPublic(gameType: GameType, accessor: { by: "id"; value: string } | { by: "code"; value: string }, caller: QueryCaller) {
+  const sessionId = getCallerUserId(caller);
+  const access = accessor.by === "id"
+    ? await getAccessByGameId(gameType, accessor.value, sessionId)
+    : await getAccessByCode(gameType, accessor.value, sessionId);
+  if (!access) {
+    throw new Error("Game not found");
+  }
+  if (access.isPublic || access.isMember || access.isHost || access.isSpectator) {
+    return;
+  }
+  throw new Error("Forbidden");
+}
+
+async function assertMember(gameType: GameType, gameId: string, caller: QueryCaller) {
+  const sessionId = requireProofUserId(caller);
+  if (!sessionId) {
+    throw new Error("Forbidden");
+  }
+  const access = await getAccessByGameId(gameType, gameId, sessionId);
+  if (!access) {
+    throw new Error("Game not found");
+  }
+  if (access.isMember || access.isHost || access.isSpectator) {
+    return;
+  }
+  throw new Error("Forbidden");
+}
+
+export async function authorizeZeroQuery(name: string, args: unknown, caller: QueryCaller) {
+  if (name === "sessions.byId") {
+    const id = typeof (args as { id?: unknown })?.id === "string" ? (args as { id: string }).id : "";
+    if (isDummyLookup(id)) {
+      return;
+    }
+    const proofUserId = requireProofUserId(caller);
+    if (!proofUserId || proofUserId !== id) {
+      throw new Error("Forbidden");
+    }
+    return;
+  }
+
+  if (name === "sessions.byGame") {
+    const payload = args as { gameType?: GameType; gameId?: string };
+    if (isDummyLookup(payload.gameId)) {
+      return;
+    }
+    if (!payload.gameType || !payload.gameId) {
+      throw new Error("Forbidden");
+    }
+    await assertMember(payload.gameType, payload.gameId, caller);
+    return;
+  }
+
+  if (name === "chat.byGame") {
+    const payload = args as { gameType?: GameType; gameId?: string };
+    if (isDummyLookup(payload.gameId)) {
+      return;
+    }
+    if (!payload.gameType || !payload.gameId) {
+      throw new Error("Forbidden");
+    }
+    await assertMember(payload.gameType, payload.gameId, caller);
+    return;
+  }
+
+  if (name === "chat.imposterByGame") {
+    const payload = args as { gameId?: string };
+    if (isDummyLookup(payload.gameId)) {
+      return;
+    }
+    const proofUserId = requireProofUserId(caller);
+    if (!proofUserId || !payload.gameId) {
+      throw new Error("Forbidden");
+    }
+    const access = await resolveGameSecretAccess("imposter", payload.gameId, proofUserId);
+    if (!access.allowed || !access.scopes.includes("imposter_chat")) {
+      throw new Error("Forbidden");
+    }
+    return;
+  }
+
+  if (name === "imposter.publicGames" || name === "password.publicGames" || name === "chainReaction.publicGames" || name === "shadeSignal.publicGames" || name === "locationSignal.publicGames") {
+    return;
+  }
+
+  if (name === "imposter.byId") {
+    const id = (args as { id: string }).id;
+    if (isDummyLookup(id)) return;
+    await assertMemberOrPublic("imposter", { by: "id", value: id }, caller);
+    return;
+  }
+  if (name === "imposter.byCode") {
+    const code = (args as { code: string }).code;
+    if (isDummyLookup(code)) return;
+    await assertMemberOrPublic("imposter", { by: "code", value: code }, caller);
+    return;
+  }
+  if (name === "password.byId") {
+    const id = (args as { id: string }).id;
+    if (isDummyLookup(id)) return;
+    await assertMemberOrPublic("password", { by: "id", value: id }, caller);
+    return;
+  }
+  if (name === "password.byCode") {
+    const code = (args as { code: string }).code;
+    if (isDummyLookup(code)) return;
+    await assertMemberOrPublic("password", { by: "code", value: code }, caller);
+    return;
+  }
+  if (name === "chainReaction.byId") {
+    const id = (args as { id: string }).id;
+    if (isDummyLookup(id)) return;
+    await assertMemberOrPublic("chain_reaction", { by: "id", value: id }, caller);
+    return;
+  }
+  if (name === "chainReaction.byCode") {
+    const code = (args as { code: string }).code;
+    if (isDummyLookup(code)) return;
+    await assertMemberOrPublic("chain_reaction", { by: "code", value: code }, caller);
+    return;
+  }
+  if (name === "shadeSignal.byId") {
+    const id = (args as { id: string }).id;
+    if (isDummyLookup(id)) return;
+    await assertMemberOrPublic("shade_signal", { by: "id", value: id }, caller);
+    return;
+  }
+  if (name === "shadeSignal.byCode") {
+    const code = (args as { code: string }).code;
+    if (isDummyLookup(code)) return;
+    await assertMemberOrPublic("shade_signal", { by: "code", value: code }, caller);
+    return;
+  }
+  if (name === "locationSignal.byId") {
+    const id = (args as { id: string }).id;
+    if (isDummyLookup(id)) return;
+    await assertMemberOrPublic("location_signal", { by: "id", value: id }, caller);
+    return;
+  }
+  if (name === "locationSignal.byCode") {
+    const code = (args as { code: string }).code;
+    if (isDummyLookup(code)) return;
+    await assertMemberOrPublic("location_signal", { by: "code", value: code }, caller);
+    return;
+  }
+
+  throw new Error("Forbidden");
+}
+
+export async function resolveGameSecretAccess(gameType: GameType, gameId: string, sessionId: string): Promise<SecretAccess> {
+  if (gameType === "imposter") {
+    const [game] = await drizzleClient
+      .select({ phase: imposterGames.phase, players: imposterGames.players, spectators: imposterGames.spectators })
+      .from(imposterGames)
+      .where(eq(imposterGames.id, gameId))
+      .limit(1);
+    if (!game) {
+      return { allowed: false, status: 404, reason: "Game not found", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const me = game.players.find((player) => player.sessionId === sessionId);
+    if (!me) {
+      const spectator = game.spectators.find((entry) => entry.sessionId === sessionId);
+      if (spectator) {
+        return { allowed: true, status: 200, keyAllowed: false, myRole: null, scopes: [] };
+      }
+      return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const revealPhase = game.phase === "results" || game.phase === "finished" || game.phase === "ended";
+    const imposterCount = game.players.filter((player) => player.role === "imposter").length;
+    const scopes = me.role === "imposter" && imposterCount >= 2 ? ["imposter_chat"] : [];
+    if (!revealPhase && game.phase !== "playing" && game.phase !== "voting") {
+      return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: me.role ?? null, scopes };
+    }
+    return {
+      allowed: true,
+      status: 200,
+      keyAllowed: revealPhase || me.role !== "imposter",
+      myRole: me.role ?? "player",
+      scopes,
+    };
+  }
+
+  if (gameType === "password") {
+    const [game] = await drizzleClient
+      .select({ phase: passwordGames.phase, teams: passwordGames.teams, activeRounds: passwordGames.activeRounds, spectators: passwordGames.spectators })
+      .from(passwordGames)
+      .where(eq(passwordGames.id, gameId))
+      .limit(1);
+    if (!game) {
+      return { allowed: false, status: 404, reason: "Game not found", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const team = game.teams.find((entry) => entry.members.includes(sessionId));
+    if (!team) {
+      const spectator = game.spectators.find((entry) => entry.sessionId === sessionId);
+      if (spectator) {
+        return { allowed: true, status: 200, keyAllowed: false, myRole: null, scopes: [] };
+      }
+      return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const isGuesser = game.phase === "playing" && game.activeRounds.some((round) => round.guesserId === sessionId);
+    return { allowed: true, status: 200, keyAllowed: !isGuesser, myRole: "player", scopes: [] };
+  }
+
+  if (gameType === "shade_signal") {
+    const [game] = await drizzleClient
+      .select({ phase: shadeSignalGames.phase, leaderId: shadeSignalGames.leaderId, players: shadeSignalGames.players, spectators: shadeSignalGames.spectators })
+      .from(shadeSignalGames)
+      .where(eq(shadeSignalGames.id, gameId))
+      .limit(1);
+    if (!game) {
+      return { allowed: false, status: 404, reason: "Game not found", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const isPlayer = game.players.some((player) => player.sessionId === sessionId);
+    if (!isPlayer) {
+      const spectator = game.spectators.find((entry) => entry.sessionId === sessionId);
+      if (spectator) {
+        return { allowed: true, status: 200, keyAllowed: false, myRole: null, scopes: [] };
+      }
+      return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const revealPhase = game.phase === "reveal" || game.phase === "finished" || game.phase === "ended";
+    return {
+      allowed: true,
+      status: 200,
+      keyAllowed: revealPhase || game.leaderId === sessionId,
+      myRole: game.leaderId === sessionId ? "leader" : "player",
+      scopes: [],
+    };
+  }
+
+  if (gameType === "location_signal") {
+    const [game] = await drizzleClient
+      .select({ phase: locationSignalGames.phase, leaderId: locationSignalGames.leaderId, players: locationSignalGames.players, spectators: locationSignalGames.spectators })
+      .from(locationSignalGames)
+      .where(eq(locationSignalGames.id, gameId))
+      .limit(1);
+    if (!game) {
+      return { allowed: false, status: 404, reason: "Game not found", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const isPlayer = game.players.some((player) => player.sessionId === sessionId);
+    if (!isPlayer) {
+      const spectator = game.spectators.find((entry) => entry.sessionId === sessionId);
+      if (spectator) {
+        return { allowed: true, status: 200, keyAllowed: false, myRole: null, scopes: [] };
+      }
+      return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: null, scopes: [] };
+    }
+    const revealPhase = game.phase === "reveal" || game.phase === "finished" || game.phase === "ended";
+    return {
+      allowed: true,
+      status: 200,
+      keyAllowed: revealPhase || game.leaderId === sessionId,
+      myRole: game.leaderId === sessionId ? "leader" : "player",
+      scopes: [],
+    };
+  }
+
+  const [game] = await drizzleClient
+    .select({ players: chainReactionGames.players, spectators: chainReactionGames.spectators })
+    .from(chainReactionGames)
+    .where(eq(chainReactionGames.id, gameId))
+    .limit(1);
+  if (!game) {
+    return { allowed: false, status: 404, reason: "Game not found", keyAllowed: false, myRole: null, scopes: [] };
+  }
+  const isPlayer = game.players.some((player) => player.sessionId === sessionId);
+  if (!isPlayer && !game.spectators.some((entry) => entry.sessionId === sessionId)) {
+    return { allowed: false, status: 403, reason: "Forbidden", keyAllowed: false, myRole: null, scopes: [] };
+  }
+  return { allowed: true, status: 200, keyAllowed: isPlayer, myRole: "player", scopes: [] };
+}

--- a/apps/api/src/shikaku-image.ts
+++ b/apps/api/src/shikaku-image.ts
@@ -258,6 +258,8 @@ const DIFF_ACCENT: Record<Difficulty, string> = {
 const README_SEED_TTL_MS = 15 * 60 * 1000;
 const README_SEED_COOKIE_MAX_AGE_SECONDS = README_SEED_TTL_MS / 1000;
 const readmeSeedCache = new Map<string, { seed: number; createdAt: number }>();
+const DEFAULT_PUBLIC_API_ORIGIN = "https://api.games.lawsonhart.me";
+const PUBLIC_API_ORIGIN = process.env.PUBLIC_API_ORIGIN?.trim() || DEFAULT_PUBLIC_API_ORIGIN;
 
 type PaddingMode = "normal" | "tight" | "none";
 
@@ -537,9 +539,7 @@ shikakuImageRoutes.get("/puzzle", (c) => {
     rememberReadmeSeed(c, difficulty, readmeScope, seed);
   }
 
-  const proto = getRequestProto(c);
-  const host = c.req.header("host") || "localhost:3001";
-  const baseUrl = `${proto}://${host}`;
+  const baseUrl = PUBLIC_API_ORIGIN.replace(/\/$/, "");
   const puzzlePageUrl = `${baseUrl}/api/shikaku/puzzle?difficulty=${difficulty}&seed=${seed}&theme=${theme}`;
   const pageUrl = showingSolution ? `${puzzlePageUrl}&solution=1` : puzzlePageUrl;
   const solutionUrl = `${puzzlePageUrl}&solution=1`;

--- a/apps/web/src/components/shared/ChatWindow.tsx
+++ b/apps/web/src/components/shared/ChatWindow.tsx
@@ -29,10 +29,17 @@ export function ChatWindow({ hostId, myName }: ChatWindowProps) {
       ? queries.chat.byGame({ gameType, gameId })
       : queries.chat.byGame({ gameType: "imposter", gameId: "__none__" })
   );
+  const [imposterMessages] = useQuery(
+    gameType === "imposter"
+      ? queries.chat.imposterByGame({ gameId })
+      : queries.chat.imposterByGame({ gameId: "__none__" })
+  );
 
   const filteredMessages = showChannels
-    ? messages.filter((m) => (m.channel ?? "all") === channel)
-    : messages.filter((m) => !m.channel || m.channel === "all");
+    ? channel === "imposter"
+      ? imposterMessages
+      : messages
+    : messages;
 
   const [minimized, setMinimized] = useState(false);
   const [input, setInput] = useState("");

--- a/apps/web/src/components/shared/PublicGamesBrowser.tsx
+++ b/apps/web/src/components/shared/PublicGamesBrowser.tsx
@@ -1,26 +1,94 @@
-import { queries, mutators } from "@games/shared";
-import { useQuery, useZero } from "../../lib/zero";
+import { mutators } from "@games/shared";
+import { useZero } from "../../lib/zero";
 import { useNavigate } from "react-router-dom";
 import { FiUsers, FiGlobe } from "react-icons/fi";
 import { addRecentGame, ensureName } from "../../lib/session";
 import { showToast } from "../../lib/toast";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type GameType = "imposter" | "password" | "chain_reaction" | "shade_signal" | "location_signal";
 
-/** Lightweight hook: just the count of public games for a given type. */
-export function usePublicGameCount(gameType: GameType): number {
-  const [imposter] = useQuery(queries.imposter.publicGames({}));
-  const [password] = useQuery(queries.password.publicGames({}));
-  const [chain] = useQuery(queries.chainReaction.publicGames({}));
-  const [shade] = useQuery(queries.shadeSignal.publicGames({}));
-  const [location] = useQuery(queries.locationSignal.publicGames({}));
+type NormalizedGame = {
+  id: string;
+  code: string;
+  phase: string;
+  hostName: string | null;
+  playerCount: number;
+  spectatorCount: number;
+  createdAt: number;
+};
 
-  if (gameType === "imposter") return imposter.length;
-  if (gameType === "password") return password.length;
-  if (gameType === "chain_reaction") return chain.length;
-  if (gameType === "shade_signal") return shade.length;
-  return location.length;
+type PublicGamesDirectory = Record<GameType, NormalizedGame[]>;
+
+const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+const EMPTY_DIRECTORY: PublicGamesDirectory = {
+  imposter: [],
+  password: [],
+  chain_reaction: [],
+  shade_signal: [],
+  location_signal: [],
+};
+
+let cachedDirectory: PublicGamesDirectory | null = null;
+let cachedAt = 0;
+let inFlightDirectoryPromise: Promise<PublicGamesDirectory> | null = null;
+
+async function loadPublicGamesDirectory(force = false): Promise<PublicGamesDirectory> {
+  const now = Date.now();
+  if (!force && cachedDirectory && now - cachedAt < 15_000) {
+    return cachedDirectory;
+  }
+  if (!force && inFlightDirectoryPromise) {
+    return inFlightDirectoryPromise;
+  }
+
+  inFlightDirectoryPromise = fetch(`${API_BASE}/api/public-games`, {
+    credentials: "include",
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      return res.json() as Promise<PublicGamesDirectory>;
+    })
+    .then((payload) => {
+      cachedDirectory = payload;
+      cachedAt = Date.now();
+      return payload;
+    })
+    .finally(() => {
+      inFlightDirectoryPromise = null;
+    });
+
+  return inFlightDirectoryPromise;
+}
+
+function usePublicGamesDirectory() {
+  const [directory, setDirectory] = useState<PublicGamesDirectory>(cachedDirectory ?? EMPTY_DIRECTORY);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadPublicGamesDirectory().then((payload) => {
+      if (!cancelled) {
+        setDirectory(payload);
+      }
+    }).catch(() => {
+      if (!cancelled) {
+        setDirectory(EMPTY_DIRECTORY);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return directory;
+}
+
+export function usePublicGameCount(gameType: GameType): number {
+  const directory = usePublicGamesDirectory();
+  return directory[gameType].length;
 }
 
 const GAME_TYPE_ROUTES: Record<GameType, (id: string) => string> = {
@@ -37,82 +105,18 @@ function isLobby(phase: string) {
   return LOBBY_PHASES.has(phase);
 }
 
-interface NormalizedGame {
-  id: string;
-  code: string;
-  phase: string;
-  hostName: string | null;
-  playerCount: number;
-  spectatorCount: number;
-  createdAt: number;
-}
-
 function usePublicGames(gameType: GameType): NormalizedGame[] {
-  const [imposterGames] = useQuery(gameType === "imposter" ? queries.imposter.publicGames({}) : queries.imposter.publicGames({}));
-  const [passwordGames] = useQuery(gameType === "password" ? queries.password.publicGames({}) : queries.password.publicGames({}));
-  const [chainGames] = useQuery(gameType === "chain_reaction" ? queries.chainReaction.publicGames({}) : queries.chainReaction.publicGames({}));
-  const [shadeGames] = useQuery(gameType === "shade_signal" ? queries.shadeSignal.publicGames({}) : queries.shadeSignal.publicGames({}));
-  const [locationGames] = useQuery(gameType === "location_signal" ? queries.locationSignal.publicGames({}) : queries.locationSignal.publicGames({}));
-
-  let games: NormalizedGame[] = [];
-
-  if (gameType === "imposter") {
-    games = imposterGames.map((g) => ({
-      id: g.id, code: g.code, phase: g.phase,
-      hostName: g.players.find((p) => p.sessionId === g.host_id)?.name ?? null,
-      playerCount: g.players.length,
-      spectatorCount: (g.spectators ?? []).length,
-      createdAt: g.created_at,
-    }));
-  } else if (gameType === "password") {
-    games = passwordGames.map((g) => ({
-      id: g.id, code: g.code, phase: g.phase,
-      hostName: null,
-      playerCount: g.teams.reduce((sum, t) => sum + t.members.length, 0),
-      spectatorCount: (g.spectators ?? []).length,
-      createdAt: g.created_at,
-    }));
-  } else if (gameType === "chain_reaction") {
-    games = chainGames.map((g) => ({
-      id: g.id, code: g.code, phase: g.phase,
-      hostName: g.players.find((p) => p.sessionId === g.host_id)?.name ?? null,
-      playerCount: g.players.length,
-      spectatorCount: (g.spectators ?? []).length,
-      createdAt: g.created_at,
-    }));
-  } else if (gameType === "shade_signal") {
-    games = shadeGames.map((g) => ({
-      id: g.id, code: g.code, phase: g.phase,
-      hostName: g.players.find((p) => p.sessionId === g.host_id)?.name ?? null,
-      playerCount: g.players.length,
-      spectatorCount: (g.spectators ?? []).length,
-      createdAt: g.created_at,
-    }));
-  } else {
-    games = locationGames.map((g) => ({
-      id: g.id, code: g.code, phase: g.phase,
-      hostName: g.players.find((p) => p.sessionId === g.host_id)?.name ?? null,
-      playerCount: g.players.length,
-      spectatorCount: (g.spectators ?? []).length,
-      createdAt: g.created_at,
-    }));
-  }
-
-  // Sort: lobby first, then newest first
+  const directory = usePublicGamesDirectory();
+  const games = [...directory[gameType]];
   games.sort((a, b) => {
     const aLobby = isLobby(a.phase) ? 0 : 1;
     const bLobby = isLobby(b.phase) ? 0 : 1;
     if (aLobby !== bLobby) return aLobby - bLobby;
     return b.createdAt - a.createdAt;
   });
-
   return games;
 }
 
-/**
- * Inline public games list for a specific game type.
- * Renders inside a game card when browsing mode is active.
- */
 export function PublicGamesList({
   gameType,
   sessionId,
@@ -147,6 +151,8 @@ export function PublicGamesList({
         if (result.type === "error") { showToast(result.error.message, "error"); return; }
       }
       addRecentGame({ id: game.id, code: game.code, gameType });
+      cachedDirectory = null;
+      cachedAt = 0;
       navigate(GAME_TYPE_ROUTES[gameType](game.id));
     } catch {
       showToast("Failed to join game", "error");

--- a/apps/web/src/hooks/useAdminBroadcast.ts
+++ b/apps/web/src/hooks/useAdminBroadcast.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import Pusher from "pusher-js";
 import { showToast } from "../lib/toast";
-import { getDisplayName, getOrCreateSessionId, getStoredName, setStoredName } from "../lib/session";
+import { getDisplayName, getOrCreateSessionId, getSessionRequestHeaders, getStoredName, setStoredName } from "../lib/session";
 
 type CustomStatusPayload = {
   text: string;
@@ -75,6 +75,7 @@ function getPusherInstance(): Pusher {
       endpoint: `${apiBase}/api/pusher/auth`,
       transport: "ajax",
       params: { session_id: sessionId },
+      headers: getSessionRequestHeaders(sessionId),
     },
   });
 

--- a/apps/web/src/hooks/usePresenceSocket.ts
+++ b/apps/web/src/hooks/usePresenceSocket.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { getSessionRequestHeaders } from "../lib/session";
 import {
   addConnectionDebugEvent,
   setPresenceConnectLatency,
@@ -41,7 +42,7 @@ export function usePresenceSocket({
       try {
         const res = await fetch(`${apiBase}/api/presence/heartbeat`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: getSessionRequestHeaders(sessionId, { "Content-Type": "application/json" }),
           credentials: "include",
           body: JSON.stringify({ sessionId, gameId, gameType }),
         });

--- a/apps/web/src/lib/chat-context.tsx
+++ b/apps/web/src/lib/chat-context.tsx
@@ -4,6 +4,7 @@ import { mutators } from "@games/shared";
 import { queries } from "@games/shared";
 import { useQuery } from "@rocicorp/zero/react";
 import { getOrCreateSessionId } from "./session";
+import { useGameSecret } from "./game-secrets";
 import { useZero } from "./zero";
 
 type ChatState = {
@@ -69,6 +70,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       ? queries.chat.byGame({ gameType: gameType!, gameId })
       : queries.chat.byGame({ gameType: "imposter", gameId: "__none__" })
   );
+  const [imposterMessages] = useQuery(
+    gameType === "imposter"
+      ? queries.chat.imposterByGame({ gameId })
+      : queries.chat.imposterByGame({ gameId: "__none__" })
+  );
 
   // Baseline = timestamp of the newest message we consider "read".
   // Initialised to Date.now() so pre-existing messages (older timestamps)
@@ -93,6 +99,12 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [shdGames] = useQuery(gameType === "shade_signal" ? queries.shadeSignal.byId({ id: gameId }) : queries.shadeSignal.byId({ id: "__none__" }));
   const [locGames] = useQuery(gameType === "location_signal" ? queries.locationSignal.byId({ id: gameId }) : queries.locationSignal.byId({ id: "__none__" }));
   const currentGame = gameType === "imposter" ? impGames[0] : gameType === "password" ? pwdGames[0] : gameType === "chain_reaction" ? chrGames[0] : gameType === "shade_signal" ? shdGames[0] : gameType === "location_signal" ? locGames[0] : null;
+  const { myRole, scopes } = useGameSecret({
+    gameType: gameType ?? "imposter",
+    gameId,
+    sessionId,
+    enabled: gameType === "imposter" && Boolean(gameId),
+  });
   const isSpectator = currentGame?.spectators?.some((s: { sessionId: string }) => s.sessionId === sessionId) ?? false;
   const currentPlayers = (currentGame as { players?: unknown[] } | null)?.players;
   const isPlayerFromPlayers = Array.isArray(currentPlayers)
@@ -143,21 +155,23 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   }, [onGameRoute, gameType, gameId, currentGame, isHost, isPlayer, isSpectator, zero, sessionId]);
 
   // Imposter role detection for private chat channels
-  const imposterGame = impGames[0];
-  const isImposter = gameType === "imposter" && imposterGame?.players?.some((p: { sessionId: string; role?: string }) => p.sessionId === sessionId && p.role === "imposter") || false;
-  const multipleImposters = gameType === "imposter" && (imposterGame?.players?.filter((p: { role?: string }) => p.role === "imposter").length ?? 0) >= 2 || false;
+  const isImposter = gameType === "imposter" && myRole === "imposter";
+  const multipleImposters = gameType === "imposter" && scopes.includes("imposter_chat");
+  const mergedMessages = multipleImposters
+    ? [...messages, ...imposterMessages].sort((left, right) => left.created_at - right.created_at)
+    : messages;
 
   useEffect(() => {
     if (open) {
-      const latest = messages.length > 0 ? messages[messages.length - 1]!.created_at : baselineTs.current;
+      const latest = mergedMessages.length > 0 ? mergedMessages[mergedMessages.length - 1]!.created_at : baselineTs.current;
       baselineTs.current = latest;
       setUnread(0);
     } else {
-      const visible = isImposter ? messages : messages.filter(m => !m.channel || m.channel === "all");
+      const visible = isImposter ? mergedMessages : messages;
       const newCount = visible.filter(m => m.created_at > baselineTs.current && m.sender_id !== sessionId).length;
       setUnread(newCount);
     }
-  }, [messages.length, open, isImposter]);
+  }, [mergedMessages, messages, open, isImposter, sessionId]);
 
   const toggle = useCallback(() => setOpen((o) => !o), []);
 

--- a/apps/web/src/lib/game-secrets.ts
+++ b/apps/web/src/lib/game-secrets.ts
@@ -17,6 +17,10 @@ interface UseGameSecretResult {
   loading: boolean;
   /** Non-null if key fetch failed or caller is not authorized (e.g. imposter player). */
   error: string | null;
+  /** Viewer-specific role metadata returned by the API. */
+  myRole: string | null;
+  /** Viewer-specific scopes returned by the API. */
+  scopes: string[];
   /**
    * Decrypts an "enc:<...>" ciphertext string.
    * Returns the original plaintext if the string is not encrypted.
@@ -39,6 +43,8 @@ interface UseGameSecretResult {
 export function useGameSecret({ gameType, gameId, sessionId, enabled = true }: UseGameSecretOptions): UseGameSecretResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [myRole, setMyRole] = useState<string | null>(null);
+  const [scopes, setScopes] = useState<string[]>([]);
   const keyRef = useRef<string | null>(null);
   const fetchedRef = useRef(false);
   const keyFetchPromiseRef = useRef<Promise<string | null> | null>(null);
@@ -49,6 +55,8 @@ export function useGameSecret({ gameType, gameId, sessionId, enabled = true }: U
     keyFetchPromiseRef.current = null;
     setError(null);
     setLoading(false);
+    setMyRole(null);
+    setScopes([]);
   }, [gameType, gameId, sessionId]);
 
   useEffect(() => {
@@ -69,9 +77,11 @@ export function useGameSecret({ gameType, gameId, sessionId, enabled = true }: U
           const body = await res.json().catch(() => ({})) as { error?: string };
           throw new Error(body.error ?? `HTTP ${res.status}`);
         }
-        const data = await res.json() as { key: string };
-        keyRef.current = data.key;
-        return data.key;
+        const data = await res.json() as { key?: string | null; myRole?: string | null; scopes?: string[] };
+        keyRef.current = typeof data.key === "string" ? data.key : null;
+        setMyRole(data.myRole ?? null);
+        setScopes(Array.isArray(data.scopes) ? data.scopes : []);
+        return keyRef.current;
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : String(err));
@@ -96,7 +106,7 @@ export function useGameSecret({ gameType, gameId, sessionId, enabled = true }: U
     }
   }, []);
 
-  return { loading, error, decryptValue };
+  return { loading, error, myRole, scopes, decryptValue };
 }
 
 /**
@@ -125,28 +135,3 @@ export async function callGameSecretInit(
   }
 }
 
-/**
- * Calls the server to decrypt the target back to plaintext BEFORE triggering the
- * reveal/scoring mutator. The scoring mutator reads the plaintext target, so this
- * must be called first. Host-only.
- */
-export async function callGameSecretPreReveal(
-  gameType: "shade_signal" | "location_signal",
-  gameId: string,
-  sessionId: string
-): Promise<void> {
-  try {
-    const res = await fetch(`${API_BASE}/api/game-secret/pre-reveal`, {
-      method: "POST",
-      credentials: "include",
-      headers: getSessionRequestHeaders(sessionId, { "Content-Type": "application/json" }),
-      body: JSON.stringify({ gameId, gameType, sessionId })
-    });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({})) as { error?: string };
-      console.warn("[game-secret/pre-reveal]", body.error ?? `HTTP ${res.status}`);
-    }
-  } catch (e) {
-    console.warn("[game-secret/pre-reveal failed]", e);
-  }
-}

--- a/apps/web/src/mobile/components/MobileChatSheet.tsx
+++ b/apps/web/src/mobile/components/MobileChatSheet.tsx
@@ -22,10 +22,17 @@ export function MobileChatSheet({ onClose }: { onClose: () => void }) {
       ? queries.chat.byGame({ gameType, gameId })
       : queries.chat.byGame({ gameType: "imposter", gameId: "__none__" })
   );
+  const [imposterMessages] = useQuery(
+    gameType === "imposter"
+      ? queries.chat.imposterByGame({ gameId })
+      : queries.chat.imposterByGame({ gameId: "__none__" })
+  );
 
   const filteredMessages = showChannels
-    ? messages.filter((m) => (m.channel ?? "all") === channel)
-    : messages.filter((m) => !m.channel || m.channel === "all");
+    ? channel === "imposter"
+      ? imposterMessages
+      : messages
+    : messages;
 
   // Get my session name
   const [sessions] = useQuery(queries.sessions.byId({ id: sessionId }));
@@ -36,8 +43,9 @@ export function MobileChatSheet({ onClose }: { onClose: () => void }) {
   const [passwordGames] = useQuery(gameType === "password" ? queries.password.byId({ id: gameId }) : queries.password.byId({ id: "__none__" }));
   const [chainGames] = useQuery(gameType === "chain_reaction" ? queries.chainReaction.byId({ id: gameId }) : queries.chainReaction.byId({ id: "__none__" }));
   const [shadeGames] = useQuery(gameType === "shade_signal" ? queries.shadeSignal.byId({ id: gameId }) : queries.shadeSignal.byId({ id: "__none__" }));
+  const [locationGames] = useQuery(gameType === "location_signal" ? queries.locationSignal.byId({ id: gameId }) : queries.locationSignal.byId({ id: "__none__" }));
 
-  const hostId = imposterGames[0]?.host_id ?? passwordGames[0]?.host_id ?? chainGames[0]?.host_id ?? shadeGames[0]?.host_id ?? "";
+  const hostId = imposterGames[0]?.host_id ?? passwordGames[0]?.host_id ?? chainGames[0]?.host_id ?? shadeGames[0]?.host_id ?? locationGames[0]?.host_id ?? "";
 
   useEffect(() => {
     if (bodyRef.current) {

--- a/apps/web/src/mobile/pages/MobileImposterPage.tsx
+++ b/apps/web/src/mobile/pages/MobileImposterPage.tsx
@@ -114,12 +114,13 @@ export function MobileImposterPage({ sessionId }: { sessionId: string }) {
     }, {});
   }, [game]);
 
-  const { decryptValue } = useGameSecret({
+  const { decryptValue, myRole } = useGameSecret({
     gameType: "imposter",
     gameId,
     sessionId,
     enabled: Boolean(game && game.phase !== "lobby")
   });
+  const liveRole = game?.phase === "playing" || game?.phase === "voting" ? (myRole ?? me?.role) : me?.role;
 
   useEffect(() => {
     let cancelled = false;
@@ -195,13 +196,14 @@ export function MobileImposterPage({ sessionId }: { sessionId: string }) {
 
   useEffect(() => {
     if (!game) return;
+    if (!isHost) return;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd || (game.phase !== "playing" && game.phase !== "voting" && game.phase !== "results")) return;
     const remaining = phaseEnd - Date.now();
-    if (remaining <= 0) { void zero.mutate(mutators.imposter.advanceTimer({ gameId })); return; }
-    const timer = setTimeout(() => { void zero.mutate(mutators.imposter.advanceTimer({ gameId })); }, remaining + 500);
+    if (remaining <= 0) { void zero.mutate(mutators.imposter.advanceTimer({ gameId })).server; return; }
+    const timer = setTimeout(() => { void zero.mutate(mutators.imposter.advanceTimer({ gameId })).server; }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost]);
 
   useEffect(() => {
     if (!game?.announcement || isHost) return;
@@ -389,7 +391,7 @@ export function MobileImposterPage({ sessionId }: { sessionId: string }) {
 
       {/* Playing: Clue section */}
       {!isSpectator && game.phase === "playing" && inGame && !me?.eliminated && (() => {
-        const isImposter = me?.role === "imposter";
+        const isImposter = liveRole === "imposter";
         const hasSubmitted = game.clues.some((c) => c.sessionId === sessionId);
         const othersClues = game.clues.filter((c) => c.sessionId !== sessionId);
 

--- a/apps/web/src/mobile/pages/MobileLocationSignalPage.tsx
+++ b/apps/web/src/mobile/pages/MobileLocationSignalPage.tsx
@@ -14,7 +14,7 @@ import { usePresenceSocket } from "../../hooks/usePresenceSocket";
 import { useMobileHostRegister } from "../../lib/mobile-host-context";
 import { addRecentGame, ensureName, getDisplayName, leaveCurrentGame, SessionGameType } from "../../lib/session";
 import { showToast } from "../../lib/toast";
-import { callGameSecretInit, callGameSecretPreReveal } from "../../lib/game-secrets";
+import { callGameSecretInit, useGameSecret } from "../../lib/game-secrets";
 
 import { WorldMap, MapMarker, fitRepeatingMapBounds } from "../../components/location/WorldMap";
 import { useGameSounds, playSoundSubmit } from "../../hooks/useGameSounds";
@@ -97,6 +97,12 @@ export function MobileLocationSignalPage({ sessionId }: { sessionId: string }) {
   }, [sessions]);
 
   const playerName = (id: string) => sessionById[id] ?? getDisplayName(null, id);
+  const { decryptValue } = useGameSecret({
+    gameType: "location_signal",
+    gameId,
+    sessionId,
+    enabled: Boolean(game && game.phase !== "lobby"),
+  });
 
   // Register host context for MobileHostControlsSheet
   useMobileHostRegister(
@@ -199,6 +205,40 @@ export function MobileLocationSignalPage({ sessionId }: { sessionId: string }) {
     setLeaderTarget(null);
   }, [game?.settings.currentRound]);
 
+  useEffect(() => {
+    let cancelled = false;
+    if (!game) {
+      setLeaderTarget(null);
+      return;
+    }
+    if (game.target_lat != null && game.target_lng != null) {
+      setLeaderTarget({ lat: game.target_lat, lng: game.target_lng });
+      return;
+    }
+    if (!game.encrypted_target) {
+      setLeaderTarget(null);
+      return;
+    }
+    void decryptValue(game.encrypted_target).then((value) => {
+      if (cancelled || !value) {
+        if (!cancelled) setLeaderTarget(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(value) as { lat?: unknown; lng?: unknown };
+        if (typeof parsed.lat === "number" && typeof parsed.lng === "number") {
+          setLeaderTarget({ lat: parsed.lat, lng: parsed.lng });
+          return;
+        }
+      } catch {
+      }
+      setLeaderTarget(null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [game?.encrypted_target, game?.target_lat, game?.target_lng, decryptValue, game]);
+
   // Auto-zoom map on phase transitions
   const autoZoomKeyRef = useRef("");
   useEffect(() => {
@@ -275,28 +315,17 @@ export function MobileLocationSignalPage({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     if (!game) return;
     if (!isHost) return;
-    const localCluePairs = (game.settings as { cluePairs?: number }).cluePairs ?? 2;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd) return;
     const activePhases: string[] = ["clue1","guess1","clue2","guess2","clue3","guess3","clue4","guess4","reveal"];
     if (!activePhases.includes(game.phase)) return;
     const remaining = phaseEnd - Date.now();
     if (remaining <= 0) {
-      if (game.phase.startsWith("guess") && Number(game.phase.replace("guess", "")) === localCluePairs) {
-        void callGameSecretPreReveal("location_signal", gameId, sessionId)
-          .then(() => zero.mutate(mutators.locationSignal.advanceTimer({ gameId })));
-      } else {
-        void zero.mutate(mutators.locationSignal.advanceTimer({ gameId }));
-      }
+      void zero.mutate(mutators.locationSignal.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      if (game.phase.startsWith("guess") && Number(game.phase.replace("guess", "")) === localCluePairs) {
-        void callGameSecretPreReveal("location_signal", gameId, sessionId)
-          .then(() => zero.mutate(mutators.locationSignal.advanceTimer({ gameId })));
-      } else {
-        void zero.mutate(mutators.locationSignal.advanceTimer({ gameId }));
-      }
+      void zero.mutate(mutators.locationSignal.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
   }, [game, game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost, sessionId]);

--- a/apps/web/src/mobile/pages/MobilePasswordGamePage.tsx
+++ b/apps/web/src/mobile/pages/MobilePasswordGamePage.tsx
@@ -198,12 +198,12 @@ export function MobilePasswordGamePage({ sessionId }: { sessionId: string }) {
   }, [game?.rounds, decryptValue]);
 
   useEffect(() => {
-    if (!game || game.phase !== "playing" || !game.settings.roundEndsAt) return;
+    if (!game || !isHost || game.phase !== "playing" || !game.settings.roundEndsAt) return;
     const remaining = game.settings.roundEndsAt - Date.now();
-    if (remaining <= 0) { void zero.mutate(mutators.password.advanceTimer({ gameId })); return; }
-    const timer = setTimeout(() => { void zero.mutate(mutators.password.advanceTimer({ gameId })); }, remaining + 500);
+    if (remaining <= 0) { void zero.mutate(mutators.password.advanceTimer({ gameId })).server; return; }
+    const timer = setTimeout(() => { void zero.mutate(mutators.password.advanceTimer({ gameId })).server; }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.roundEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.roundEndsAt, game?.phase, gameId, zero, isHost]);
 
   useEffect(() => { if (game?.phase === "results") navigate(`/password/${game.id}/results`); }, [game?.phase, game?.id, navigate]);
   useEffect(() => {

--- a/apps/web/src/mobile/pages/MobileShadeSignalPage.tsx
+++ b/apps/web/src/mobile/pages/MobileShadeSignalPage.tsx
@@ -15,7 +15,7 @@ import { MobileSpectatorOverlay } from "../../components/shared/SpectatorOverlay
 import { usePresenceSocket } from "../../hooks/usePresenceSocket";
 import { addRecentGame, ensureName, getDisplayName, leaveCurrentGame, SessionGameType } from "../../lib/session";
 import { showToast } from "../../lib/toast";
-import { callGameSecretInit, callGameSecretPreReveal } from "../../lib/game-secrets";
+import { useGameSecret } from "../../lib/game-secrets";
 
 import { useMobileHostRegister } from "../../lib/mobile-host-context";
 import { useGameSounds, playSoundSubmit } from "../../hooks/useGameSounds";
@@ -76,6 +76,7 @@ export function MobileShadeSignalPage({ sessionId }: { sessionId: string }) {
   const game = games[0];
   const [clue, setClue] = useState("");
   const [selectedCell, setSelectedCell] = useState<{ row: number; col: number } | null>(null);
+  const [leaderTarget, setLeaderTarget] = useState<{ row: number; col: number } | null>(null);
   const [guessLocked, setGuessLocked] = useState(false);
   const [lobbyPreviewTarget, setLobbyPreviewTarget] = useState<{ row: number; col: number } | null>(null);
   const [showInSessionModal, setShowInSessionModal] = useState(false);
@@ -135,6 +136,12 @@ export function MobileShadeSignalPage({ sessionId }: { sessionId: string }) {
       return acc;
     }, {});
   }, [sessions]);
+  const { decryptValue } = useGameSecret({
+    gameType: "shade_signal",
+    gameId,
+    sessionId,
+    enabled: Boolean(game && game.phase !== "lobby"),
+  });
 
   const playerIndexMap = useMemo(() => {
     return game?.players.reduce<Record<string, number>>((acc, player, playerIndex) => {
@@ -170,20 +177,21 @@ export function MobileShadeSignalPage({ sessionId }: { sessionId: string }) {
   // Timer auto-advance
   useEffect(() => {
     if (!game) return;
+    if (!isHost) return;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd) return;
     const activePhases: ShadePhase[] = ["clue1", "guess1", "clue2", "guess2", "reveal"];
     if (!activePhases.includes(game.phase as ShadePhase)) return;
     const remaining = phaseEnd - Date.now();
     if (remaining <= 0) {
-      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId }));
+      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId }));
+      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost]);
 
   useEffect(() => {
     if (!game?.announcement || isHost) return;
@@ -205,13 +213,46 @@ export function MobileShadeSignalPage({ sessionId }: { sessionId: string }) {
   }, [game?.phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    let cancelled = false;
+    if (!game) {
+      setLeaderTarget(null);
+      return;
+    }
+    if (game.target_row != null && game.target_col != null && game.target_row >= 0 && game.target_col >= 0) {
+      setLeaderTarget({ row: game.target_row, col: game.target_col });
+      return;
+    }
+    if (!game.encrypted_target) {
+      setLeaderTarget(null);
+      return;
+    }
+    void decryptValue(game.encrypted_target).then((value) => {
+      if (cancelled || !value) {
+        if (!cancelled) setLeaderTarget(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(value) as { row?: unknown; col?: unknown };
+        if (typeof parsed.row === "number" && typeof parsed.col === "number") {
+          setLeaderTarget({ row: parsed.row, col: parsed.col });
+          return;
+        }
+      } catch {
+      }
+      setLeaderTarget(null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [game?.encrypted_target, game?.target_row, game?.target_col, decryptValue, game]);
+
+  useEffect(() => {
     if (!game || game.phase !== "reveal") return;
     if (game.host_id !== sessionId) return;
     const latest = game.round_history[game.round_history.length - 1];
     if (latest) return;
     const timer = setTimeout(() => {
-      void callGameSecretPreReveal("shade_signal", gameId, sessionId)
-        .then(() => zero.mutate(mutators.shadeSignal.reveal({ gameId })));
+      void zero.mutate(mutators.shadeSignal.reveal({ gameId })).server;
     }, 600);
     return () => clearTimeout(timer);
   }, [game?.phase, game?.round_history.length, gameId, sessionId, zero]);
@@ -233,7 +274,7 @@ export function MobileShadeSignalPage({ sessionId }: { sessionId: string }) {
 
   const target = game?.target_row != null && game?.target_col != null && game.target_row >= 0 && game.target_col >= 0
     ? { row: game.target_row, col: game.target_col }
-    : null;
+    : leaderTarget;
 
   const targetColor = target && game
     ? generateGridColor(target.row, target.col, game.grid_rows, game.grid_cols, game.grid_seed)

--- a/apps/web/src/pages/ImposterPage.tsx
+++ b/apps/web/src/pages/ImposterPage.tsx
@@ -108,12 +108,13 @@ function ImposterPageDesktop({ sessionId }: { sessionId: string }) {
     }, {});
   }, [game]);
 
-  const { decryptValue } = useGameSecret({
+  const { decryptValue, myRole } = useGameSecret({
     gameType: "imposter",
     gameId,
     sessionId,
     enabled: Boolean(game && game.phase !== "lobby")
   });
+  const liveRole = game?.phase === "playing" || game?.phase === "voting" ? (myRole ?? me?.role) : me?.role;
 
   useEffect(() => {
     let cancelled = false;
@@ -186,18 +187,19 @@ function ImposterPageDesktop({ sessionId }: { sessionId: string }) {
   // Timer auto-advance
   useEffect(() => {
     if (!game) return;
+    if (!isHost) return;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd || (game.phase !== "playing" && game.phase !== "voting" && game.phase !== "results")) return;
     const remaining = phaseEnd - Date.now();
     if (remaining <= 0) {
-      void zero.mutate(mutators.imposter.advanceTimer({ gameId }));
+      void zero.mutate(mutators.imposter.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      void zero.mutate(mutators.imposter.advanceTimer({ gameId }));
+      void zero.mutate(mutators.imposter.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost]);
 
   // Announcement watcher (skip for host - they sent it)
   useEffect(() => {
@@ -345,7 +347,7 @@ function ImposterPageDesktop({ sessionId }: { sessionId: string }) {
         const activePlayers = game.players.filter((p) => !p.eliminated);
         return (
           <ImposterClueSection
-            role={me?.role}
+            role={liveRole === "imposter" || liveRole === "player" ? liveRole : undefined}
             secretWord={visibleSecretWord}
             category={game.category ?? null}
             clue={clue}

--- a/apps/web/src/pages/LocationSignalPage.tsx
+++ b/apps/web/src/pages/LocationSignalPage.tsx
@@ -14,7 +14,7 @@ import { usePresenceSocket } from "../hooks/usePresenceSocket";
 import { addRecentGame, ensureName, getDisplayName, leaveCurrentGame, SessionGameType } from "../lib/session";
 import { showToast } from "../lib/toast";
 import { useIsMobile } from "../hooks/useIsMobile";
-import { callGameSecretInit, callGameSecretPreReveal } from "../lib/game-secrets";
+import { callGameSecretInit, useGameSecret } from "../lib/game-secrets";
 
 import { MobileLocationSignalPage } from "../mobile/pages/MobileLocationSignalPage";
 import { WorldMap, MapMarker, fitRepeatingMapBounds } from "../components/location/WorldMap";
@@ -118,6 +118,12 @@ function LocationSignalPageDesktop({ sessionId }: { sessionId: string }) {
   }, [sessions]);
 
   const playerName = (id: string) => sessionById[id] ?? getDisplayName(null, id);
+  const { decryptValue } = useGameSecret({
+    gameType: "location_signal",
+    gameId,
+    sessionId,
+    enabled: Boolean(game && game.phase !== "lobby"),
+  });
 
   const myRoundGuess = useMemo(() => {
     if (!game) return null;
@@ -175,6 +181,40 @@ function LocationSignalPageDesktop({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     setLeaderTarget(null);
   }, [game?.settings.currentRound]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!game) {
+      setLeaderTarget(null);
+      return;
+    }
+    if (game.target_lat != null && game.target_lng != null) {
+      setLeaderTarget({ lat: game.target_lat, lng: game.target_lng });
+      return;
+    }
+    if (!game.encrypted_target) {
+      setLeaderTarget(null);
+      return;
+    }
+    void decryptValue(game.encrypted_target).then((value) => {
+      if (cancelled || !value) {
+        if (!cancelled) setLeaderTarget(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(value) as { lat?: unknown; lng?: unknown };
+        if (typeof parsed.lat === "number" && typeof parsed.lng === "number") {
+          setLeaderTarget({ lat: parsed.lat, lng: parsed.lng });
+          return;
+        }
+      } catch {
+      }
+      setLeaderTarget(null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [game?.encrypted_target, game?.target_lat, game?.target_lng, decryptValue, game]);
 
   // Auto-zoom map on phase transitions
   const autoZoomKeyRef = useRef("");
@@ -259,28 +299,17 @@ function LocationSignalPageDesktop({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     if (!game) return;
     if (!isHost) return;
-    const localCluePairs = (game.settings as { cluePairs?: number }).cluePairs ?? 2;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd) return;
     const activePhases: string[] = ["clue1","guess1","clue2","guess2","clue3","guess3","clue4","guess4","reveal"];
     if (!activePhases.includes(game.phase)) return;
     const remaining = phaseEnd - Date.now();
     if (remaining <= 0) {
-      if (game.phase.startsWith("guess") && Number(game.phase.replace("guess", "")) === localCluePairs) {
-        void callGameSecretPreReveal("location_signal", gameId, sessionId)
-          .then(() => zero.mutate(mutators.locationSignal.advanceTimer({ gameId })));
-      } else {
-        void zero.mutate(mutators.locationSignal.advanceTimer({ gameId }));
-      }
+      void zero.mutate(mutators.locationSignal.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      if (game.phase.startsWith("guess") && Number(game.phase.replace("guess", "")) === localCluePairs) {
-        void callGameSecretPreReveal("location_signal", gameId, sessionId)
-          .then(() => zero.mutate(mutators.locationSignal.advanceTimer({ gameId })));
-      } else {
-        void zero.mutate(mutators.locationSignal.advanceTimer({ gameId }));
-      }
+      void zero.mutate(mutators.locationSignal.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
   }, [game, game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost, sessionId]);

--- a/apps/web/src/pages/PasswordGamePage.tsx
+++ b/apps/web/src/pages/PasswordGamePage.tsx
@@ -186,17 +186,17 @@ function PasswordGamePageDesktop({ sessionId }: { sessionId: string }) {
 
   // Auto-advance timer
   useEffect(() => {
-    if (!game || game.phase !== "playing" || !game.settings.roundEndsAt) return;
+    if (!game || !isHost || game.phase !== "playing" || !game.settings.roundEndsAt) return;
     const remaining = game.settings.roundEndsAt - Date.now();
     if (remaining <= 0) {
-      void zero.mutate(mutators.password.advanceTimer({ gameId }));
+      void zero.mutate(mutators.password.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      void zero.mutate(mutators.password.advanceTimer({ gameId }));
+      void zero.mutate(mutators.password.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.roundEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.roundEndsAt, game?.phase, gameId, zero, isHost]);
 
   // Auto-navigate to results when game ends
   useEffect(() => {

--- a/apps/web/src/pages/ShadeSignalPage.tsx
+++ b/apps/web/src/pages/ShadeSignalPage.tsx
@@ -17,7 +17,7 @@ import { usePresenceSocket } from "../hooks/usePresenceSocket";
 import { addRecentGame, ensureName, getDisplayName, leaveCurrentGame, SessionGameType } from "../lib/session";
 import { showToast } from "../lib/toast";
 import { useIsMobile } from "../hooks/useIsMobile";
-import { callGameSecretInit, callGameSecretPreReveal } from "../lib/game-secrets";
+import { callGameSecretInit, useGameSecret } from "../lib/game-secrets";
 
 import { MobileShadeSignalPage } from "../mobile/pages/MobileShadeSignalPage";
 import { ShadeDemo } from "../components/demos/ShadeDemo";
@@ -101,6 +101,7 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
   const [clue, setClue] = useState("");
   const [selectedCell, setSelectedCell] = useState<{ row: number; col: number } | null>(null);
   const [pickingCell, setPickingCell] = useState<{ row: number; col: number } | null>(null);
+  const [leaderTarget, setLeaderTarget] = useState<{ row: number; col: number } | null>(null);
   const [guessLocked, setGuessLocked] = useState(false);
   const [copied, setCopied] = useState(false);
   const [lobbyPreviewTarget, setLobbyPreviewTarget] = useState<{ row: number; col: number } | null>(null);
@@ -173,6 +174,12 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
       return acc;
     }, {}) ?? {};
   }, [game?.players]);
+  const { decryptValue } = useGameSecret({
+    gameType: "shade_signal",
+    gameId,
+    sessionId,
+    enabled: Boolean(game && game.phase !== "lobby"),
+  });
 
   useEffect(() => {
     if (!game) return;
@@ -195,20 +202,21 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
   // Timer auto-advance
   useEffect(() => {
     if (!game) return;
+    if (!isHost) return;
     const phaseEnd = game.settings.phaseEndsAt;
     if (!phaseEnd) return;
     const activePhases: ShadePhase[] = ["clue1", "guess1", "clue2", "guess2", "reveal"];
     if (!activePhases.includes(game.phase as ShadePhase)) return;
     const remaining = phaseEnd - Date.now();
     if (remaining <= 0) {
-      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId }));
+      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId })).server;
       return;
     }
     const timer = setTimeout(() => {
-      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId }));
+      void zero.mutate(mutators.shadeSignal.advanceTimer({ gameId })).server;
     }, remaining + 500);
     return () => clearTimeout(timer);
-  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero]);
+  }, [game?.settings.phaseEndsAt, game?.phase, gameId, zero, isHost]);
 
   // Announcement watcher
   useEffect(() => {
@@ -231,6 +239,40 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
     setGuessLocked(false);
   }, [game?.phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    let cancelled = false;
+    if (!game) {
+      setLeaderTarget(null);
+      return;
+    }
+    if (game.target_row != null && game.target_col != null && game.target_row >= 0 && game.target_col >= 0) {
+      setLeaderTarget({ row: game.target_row, col: game.target_col });
+      return;
+    }
+    if (!game.encrypted_target) {
+      setLeaderTarget(null);
+      return;
+    }
+    void decryptValue(game.encrypted_target).then((value) => {
+      if (cancelled || !value) {
+        if (!cancelled) setLeaderTarget(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(value) as { row?: unknown; col?: unknown };
+        if (typeof parsed.row === "number" && typeof parsed.col === "number") {
+          setLeaderTarget({ row: parsed.row, col: parsed.col });
+          return;
+        }
+      } catch {
+      }
+      setLeaderTarget(null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [game?.encrypted_target, game?.target_row, game?.target_col, decryptValue, game]);
+
   // Auto-reveal: when entering reveal phase, auto-calculate scores
   useEffect(() => {
     if (!game || game.phase !== "reveal") return;
@@ -239,8 +281,7 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
     const latest = game.round_history[game.round_history.length - 1];
     if (latest && latest.round === game.settings.currentRound) return; // already revealed this round
     const timer = setTimeout(() => {
-      void callGameSecretPreReveal("shade_signal", gameId, sessionId)
-        .then(() => zero.mutate(mutators.shadeSignal.reveal({ gameId })));
+      void zero.mutate(mutators.shadeSignal.reveal({ gameId })).server;
     }, 600);
     return () => clearTimeout(timer);
   }, [game?.phase, game?.round_history.length, gameId, sessionId, zero]);
@@ -250,7 +291,7 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
 
   const target = game?.target_row != null && game?.target_col != null && game.target_row >= 0 && game.target_col >= 0
     ? { row: game.target_row, col: game.target_col }
-    : null;
+    : leaderTarget;
 
   const targetColor = target && game
     ? generateGridColor(target.row, target.col, game.grid_rows, game.grid_cols, game.grid_seed)
@@ -604,6 +645,7 @@ function ShadeSignalPageDesktop({ sessionId }: { sessionId: string }) {
               <button
                 className="btn btn-primary game-action-btn"
                 onClick={() => {
+                  setLeaderTarget({ row: pickingCell.row, col: pickingCell.col });
                   void zero.mutate(mutators.shadeSignal.setTarget({
                     gameId, sessionId,
                     row: pickingCell.row, col: pickingCell.col

--- a/packages/shared/drizzle/0012_security_views.sql
+++ b/packages/shared/drizzle/0012_security_views.sql
@@ -1,0 +1,122 @@
+CREATE OR REPLACE VIEW "imposter_public_games" AS
+SELECT
+  "id",
+  "code",
+  "host_id",
+  "phase",
+  "category",
+  CASE
+    WHEN "phase" IN ('results', 'finished', 'ended') THEN "secret_word"
+    WHEN "secret_word" LIKE 'enc:%' THEN "secret_word"
+    ELSE NULL
+  END AS "secret_word",
+  CASE
+    WHEN "phase" IN ('results', 'finished', 'ended') THEN "players"
+    ELSE (
+      SELECT COALESCE(jsonb_agg("player" - 'role'), '[]'::jsonb)
+      FROM jsonb_array_elements("players") AS "player"
+    )
+  END AS "players",
+  "clues",
+  "votes",
+  "spectators",
+  "kicked",
+  CASE
+    WHEN "phase" IN ('results', 'finished', 'ended') THEN "round_history"
+    ELSE (
+      SELECT COALESCE(
+        jsonb_agg(jsonb_set("round_entry", '{secretWord}', 'null'::jsonb, true)),
+        '[]'::jsonb
+      )
+      FROM jsonb_array_elements("round_history") AS "round_entry"
+    )
+  END AS "round_history",
+  "announcement",
+  "settings",
+  "is_public",
+  "created_at",
+  "updated_at"
+FROM "imposter_games";
+
+CREATE OR REPLACE VIEW "imposter_public_game_summaries" AS
+SELECT
+  "id",
+  "code",
+  "phase",
+  (
+    SELECT "player" ->> 'name'
+    FROM jsonb_array_elements("players") AS "player"
+    WHERE "player" ->> 'sessionId' = "host_id"
+    LIMIT 1
+  ) AS "host_name",
+  jsonb_array_length("players")::int AS "player_count",
+  jsonb_array_length("spectators")::int AS "spectator_count",
+  "created_at"
+FROM "imposter_games"
+WHERE "is_public" = true AND "phase" <> 'ended';
+
+CREATE OR REPLACE VIEW "password_public_game_summaries" AS
+SELECT
+  "id",
+  "code",
+  "phase",
+  NULL::text AS "host_name",
+  COALESCE((
+    SELECT SUM(jsonb_array_length("team" -> 'members'))
+    FROM jsonb_array_elements("teams") AS "team"
+  ), 0)::int AS "player_count",
+  jsonb_array_length("spectators")::int AS "spectator_count",
+  "created_at"
+FROM "password_games"
+WHERE "is_public" = true AND "phase" <> 'ended';
+
+CREATE OR REPLACE VIEW "chain_reaction_public_game_summaries" AS
+SELECT
+  "id",
+  "code",
+  "phase",
+  (
+    SELECT "player" ->> 'name'
+    FROM jsonb_array_elements("players") AS "player"
+    WHERE "player" ->> 'sessionId' = "host_id"
+    LIMIT 1
+  ) AS "host_name",
+  jsonb_array_length("players")::int AS "player_count",
+  jsonb_array_length("spectators")::int AS "spectator_count",
+  "created_at"
+FROM "chain_reaction_games"
+WHERE "is_public" = true AND "phase" NOT IN ('ended', 'finished');
+
+CREATE OR REPLACE VIEW "shade_signal_public_game_summaries" AS
+SELECT
+  "id",
+  "code",
+  "phase",
+  (
+    SELECT "player" ->> 'name'
+    FROM jsonb_array_elements("players") AS "player"
+    WHERE "player" ->> 'sessionId' = "host_id"
+    LIMIT 1
+  ) AS "host_name",
+  jsonb_array_length("players")::int AS "player_count",
+  jsonb_array_length("spectators")::int AS "spectator_count",
+  "created_at"
+FROM "shade_signal_games"
+WHERE "is_public" = true AND "phase" <> 'ended';
+
+CREATE OR REPLACE VIEW "location_signal_public_game_summaries" AS
+SELECT
+  "id",
+  "code",
+  "phase",
+  (
+    SELECT "player" ->> 'name'
+    FROM jsonb_array_elements("players") AS "player"
+    WHERE "player" ->> 'sessionId' = "host_id"
+    LIMIT 1
+  ) AS "host_name",
+  jsonb_array_length("players")::int AS "player_count",
+  jsonb_array_length("spectators")::int AS "spectator_count",
+  "created_at"
+FROM "location_signal_games"
+WHERE "is_public" = true AND "phase" <> 'ended';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,9 @@
     "test:local": "vitest run --config vitest.local.config.ts --passWithNoTests",
     "test:watch": "vitest --watch",
     "db:generate": "drizzle-kit generate",
-    "db:push": "drizzle-kit push",
+    "db:prepare-zero-sync-schema": "bun run ./scripts/prepare-zero-sync-schema.ts",
+    "db:sync-zero-public-data": "bun run ./scripts/sync-zero-public-data.ts",
+    "db:push": "bun run db:prepare-zero-sync-schema && drizzle-kit push && bun run db:sync-zero-public-data",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/packages/shared/scripts/prepare-zero-sync-schema.ts
+++ b/packages/shared/scripts/prepare-zero-sync-schema.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
+import pg from "pg";
+
+config({ path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../.env") });
+
+const { Client } = pg;
+
+const LEGACY_VIEWS = [
+  "imposter_public_game_summaries",
+  "password_public_game_summaries",
+  "chain_reaction_public_game_summaries",
+  "shade_signal_public_game_summaries",
+  "location_signal_public_game_summaries",
+  "imposter_public_games",
+] as const;
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim() || "postgres://postgres:postgres@localhost:5432/games";
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    for (const viewName of LEGACY_VIEWS) {
+      await client.query(`drop view if exists "${viewName}" cascade`);
+    }
+    console.log(`[db:prepare-zero-sync-schema] dropped legacy Zero views if present`);
+  } finally {
+    await client.end();
+  }
+}
+
+await main();

--- a/packages/shared/scripts/sync-zero-public-data.ts
+++ b/packages/shared/scripts/sync-zero-public-data.ts
@@ -1,0 +1,147 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { config } from "dotenv";
+import pg from "pg";
+
+config({ path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../.env") });
+
+const { Client } = pg;
+
+type ImposterPlayer = {
+  sessionId: string;
+  name: string | null;
+  connected: boolean;
+  role?: "imposter" | "player";
+  eliminated?: boolean;
+};
+
+type ImposterRoundHistoryEntry = {
+  round: number;
+  secretWord: string | null;
+  votedOutId: string | null;
+  votedOutName: string | null;
+  wasImposter: boolean;
+  clues: Array<{ sessionId: string; text: string }>;
+  votes: Array<{ voterId: string; targetId: string }>;
+};
+
+function redactPlayers(phase: string, players: ImposterPlayer[]) {
+  if (phase === "results" || phase === "finished" || phase === "ended") {
+    return players;
+  }
+  return players.map(({ role: _role, ...player }) => player);
+}
+
+function redactRoundHistory(phase: string, roundHistory: ImposterRoundHistoryEntry[]) {
+  if (phase === "results" || phase === "finished" || phase === "ended") {
+    return roundHistory;
+  }
+  return roundHistory.map((entry) => ({ ...entry, secretWord: null }));
+}
+
+function redactSecretWord(phase: string, secretWord: string | null) {
+  if (!secretWord) return null;
+  if (phase === "results" || phase === "finished" || phase === "ended") {
+    return secretWord;
+  }
+  return secretWord.startsWith("enc:") ? secretWord : null;
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL?.trim() || "postgres://postgres:postgres@localhost:5432/games";
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    await client.query("begin");
+
+    const result = await client.query(`
+      select
+        id,
+        code,
+        host_id,
+        phase,
+        category,
+        secret_word,
+        players,
+        clues,
+        votes,
+        spectators,
+        kicked,
+        round_history,
+        announcement,
+        settings,
+        is_public,
+        created_at,
+        updated_at
+      from imposter_games
+    `);
+
+    for (const row of result.rows) {
+      const phase = row.phase as string;
+      const players = (row.players ?? []) as ImposterPlayer[];
+      const roundHistory = (row.round_history ?? []) as ImposterRoundHistoryEntry[];
+
+      await client.query(
+        `insert into imposter_public_games (
+          id, code, host_id, phase, category, secret_word, players, clues, votes, spectators,
+          kicked, round_history, announcement, settings, is_public, created_at, updated_at
+        ) values (
+          $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb,
+          $11::jsonb, $12::jsonb, $13::jsonb, $14::jsonb, $15, $16, $17
+        )
+        on conflict (id) do update set
+          code = excluded.code,
+          host_id = excluded.host_id,
+          phase = excluded.phase,
+          category = excluded.category,
+          secret_word = excluded.secret_word,
+          players = excluded.players,
+          clues = excluded.clues,
+          votes = excluded.votes,
+          spectators = excluded.spectators,
+          kicked = excluded.kicked,
+          round_history = excluded.round_history,
+          announcement = excluded.announcement,
+          settings = excluded.settings,
+          is_public = excluded.is_public,
+          created_at = excluded.created_at,
+          updated_at = excluded.updated_at`,
+        [
+          row.id,
+          row.code,
+          row.host_id,
+          row.phase,
+          row.category,
+          redactSecretWord(phase, row.secret_word),
+          JSON.stringify(redactPlayers(phase, players)),
+          JSON.stringify(row.clues ?? []),
+          JSON.stringify(row.votes ?? []),
+          JSON.stringify(row.spectators ?? []),
+          JSON.stringify(row.kicked ?? []),
+          JSON.stringify(redactRoundHistory(phase, roundHistory)),
+          JSON.stringify(row.announcement ?? null),
+          JSON.stringify(row.settings ?? {}),
+          row.is_public,
+          row.created_at,
+          row.updated_at,
+        ]
+      );
+    }
+
+    await client.query(`
+      delete from imposter_public_games
+      where id not in (select id from imposter_games)
+    `);
+
+    await client.query("commit");
+    console.log(`[db:sync-zero-public-data] synced ${result.rows.length} imposter public rows`);
+  } catch (error) {
+    await client.query("rollback").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+await main();

--- a/packages/shared/src/__tests__/chat-sessions.test.ts
+++ b/packages/shared/src/__tests__/chat-sessions.test.ts
@@ -9,6 +9,7 @@ import {
   MockTx,
   serverCtx,
   makeSession,
+  makeImposterGame,
   expectThrows,
 } from "./test-helpers";
 
@@ -61,6 +62,16 @@ describe("Chat — send message", () => {
 
   beforeEach(() => {
     tx = new MockTx("server");
+    tx.seed("imposter_games", [
+      makeImposterGame({
+        id: "game1",
+        host_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, role: "player" },
+          { sessionId: "user1", name: "Alice", connected: true, role: "player" },
+        ],
+      }),
+    ]);
   });
 
   it("sends a valid message", async () => {
@@ -171,6 +182,101 @@ describe("Chat — send message", () => {
     const msg = tx.getById("chat_messages", "msg6") as any;
     expect(msg.sender_name).toBe(fallbackPlayerName("user1"));
   });
+
+  it("blocks outsiders from sending messages into a game", async () => {
+    tx.seed("imposter_games", [
+      makeImposterGame({
+        id: "game1",
+        host_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, role: "player" },
+          { sessionId: "user1", name: "Alice", connected: true, role: "player" },
+        ],
+      }),
+    ]);
+
+    await expectThrows(
+      () =>
+        chat.send({
+          args: {
+            id: "msg7",
+            gameType: "imposter",
+            gameId: "game1",
+            senderId: "attacker",
+            senderName: "Mallory",
+            text: "let me in",
+          },
+          tx,
+          ctx: serverCtx("attacker"),
+        }),
+      "Only game members can chat"
+    );
+  });
+
+  it("allows imposter-only chat for real imposters", async () => {
+    tx.seed("imposter_games", [
+      makeImposterGame({
+        id: "game1",
+        host_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, role: "player" },
+          { sessionId: "imp1", name: "Ivy", connected: true, role: "imposter" },
+          { sessionId: "imp2", name: "Noah", connected: true, role: "imposter" },
+          { sessionId: "user1", name: "Alice", connected: true, role: "player" },
+        ],
+      }),
+    ]);
+
+    await chat.send({
+      args: {
+        id: "msg8",
+        gameType: "imposter",
+        gameId: "game1",
+        senderId: "imp1",
+        senderName: "Ivy",
+        channel: "imposter",
+        text: "stick with the museum clue",
+      },
+      tx,
+      ctx: serverCtx("imp1"),
+    });
+
+    const msg = tx.getById("chat_messages", "msg8") as any;
+    expect(msg.channel).toBe("imposter");
+  });
+
+  it("blocks non-imposters from using the imposter channel", async () => {
+    tx.seed("imposter_games", [
+      makeImposterGame({
+        id: "game1",
+        host_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, role: "player" },
+          { sessionId: "imp1", name: "Ivy", connected: true, role: "imposter" },
+          { sessionId: "imp2", name: "Noah", connected: true, role: "imposter" },
+          { sessionId: "user1", name: "Alice", connected: true, role: "player" },
+        ],
+      }),
+    ]);
+
+    await expectThrows(
+      () =>
+        chat.send({
+          args: {
+            id: "msg9",
+            gameType: "imposter",
+            gameId: "game1",
+            senderId: "user1",
+            senderName: "Alice",
+            channel: "imposter",
+            text: "hello fellow imposters",
+          },
+          tx,
+          ctx: serverCtx("user1"),
+        }),
+      "Only imposters can use this channel"
+    );
+  });
 });
 
 // ───────────────────────────────────────────────────────────
@@ -187,6 +293,7 @@ describe("Chat — clearForGame", () => {
   });
 
   it("deletes all messages for the specified game", async () => {
+    tx.seed("imposter_games", [makeImposterGame({ id: "game1", host_id: "host1" })]);
     await chat.clearForGame({
       args: { gameType: "imposter", gameId: "game1" },
       tx,
@@ -197,6 +304,29 @@ describe("Chat — clearForGame", () => {
     expect(tx.getById("chat_messages", "m2")).toBeUndefined();
     // Messages for game2 should remain
     expect(tx.getById("chat_messages", "m3")).toBeDefined();
+  });
+
+  it("blocks non-hosts from clearing a game's chat log", async () => {
+    tx.seed("imposter_games", [
+      makeImposterGame({
+        id: "game1",
+        host_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, role: "player" },
+          { sessionId: "user1", name: "Alice", connected: true, role: "player" },
+        ],
+      }),
+    ]);
+
+    await expectThrows(
+      () =>
+        chat.clearForGame({
+          args: { gameType: "imposter", gameId: "game1" },
+          tx,
+          ctx: serverCtx("user1"),
+        }),
+      "Only host can do that"
+    );
   });
 });
 

--- a/packages/shared/src/__tests__/location-signal.test.ts
+++ b/packages/shared/src/__tests__/location-signal.test.ts
@@ -137,6 +137,62 @@ describe("Location Signal — identity enforcement", () => {
     const game = tx.getById("location_signal_games", "game1") as any;
     expect(game.kicked).toContain("attacker");
   });
+
+  it("blocks outsiders from submitting guesses", async () => {
+    tx.seed("location_signal_games", [
+      makeLocationSignalGame({
+        id: "game2",
+        host_id: "host1",
+        phase: "guess1",
+        leader_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, totalScore: 0 },
+          { sessionId: "p1", name: "Alice", connected: true, totalScore: 0 },
+        ],
+      }),
+    ]);
+
+    await expectThrows(
+      () => mutators.submitGuess({
+        args: { gameId: "game2", sessionId: "attacker", round: 1, lat: 10, lng: 20 },
+        tx,
+        ctx: serverCtx("attacker"),
+      }),
+      "Only players in the game can guess"
+    );
+  });
+
+  it("blocks non-hosts from advancing timers", async () => {
+    tx.seed("location_signal_games", [
+      makeLocationSignalGame({
+        id: "game3",
+        host_id: "host1",
+        phase: "clue1",
+        leader_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, totalScore: 0 },
+          { sessionId: "p1", name: "Alice", connected: true, totalScore: 0 },
+        ],
+        settings: {
+          clueDurationSec: 60,
+          guessDurationSec: 30,
+          roundsPerPlayer: 2,
+          currentRound: 1,
+          phaseEndsAt: Date.now() - 1_000,
+          cluePairs: 2,
+        },
+      }),
+    ]);
+
+    await expectThrows(
+      () => mutators.advanceTimer({
+        args: { gameId: "game3" },
+        tx,
+        ctx: serverCtx("p1"),
+      }),
+      "Only host can do that"
+    );
+  });
 });
 
 // ───────────────────────────────────────────────────────────

--- a/packages/shared/src/__tests__/shade-signal.test.ts
+++ b/packages/shared/src/__tests__/shade-signal.test.ts
@@ -140,6 +140,66 @@ describe("Shade Signal — identity enforcement", () => {
     expect(game.kicked).toContain("attacker");
     expect(game.players.find((p: any) => p.sessionId === "attacker")).toBeUndefined();
   });
+
+  it("blocks non-hosts from advancing timers", async () => {
+    tx.seed("shade_signal_games", [
+      makeShadeSignalGame({
+        id: "game2",
+        host_id: "host1",
+        phase: "clue1",
+        leader_id: "host1",
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, totalScore: 0 },
+          { sessionId: "p1", name: "Alice", connected: true, totalScore: 0 },
+          { sessionId: "p2", name: "Bob", connected: true, totalScore: 0 },
+        ],
+        settings: {
+          hardMode: false,
+          clueDurationSec: 45,
+          guessDurationSec: 30,
+          roundsPerPlayer: 1,
+          currentRound: 1,
+          phaseEndsAt: Date.now() - 1_000,
+        },
+      }),
+    ]);
+
+    await expectThrows(
+      () => mutators.advanceTimer({
+        args: { gameId: "game2" },
+        tx,
+        ctx: serverCtx("p1"),
+      }),
+      "Only host can do that"
+    );
+  });
+
+  it("blocks non-hosts from running reveal", async () => {
+    tx.seed("shade_signal_games", [
+      makeShadeSignalGame({
+        id: "game3",
+        host_id: "host1",
+        phase: "reveal",
+        leader_id: "host1",
+        target_row: 2,
+        target_col: 3,
+        players: [
+          { sessionId: "host1", name: "Host", connected: true, totalScore: 0 },
+          { sessionId: "p1", name: "Alice", connected: true, totalScore: 0 },
+          { sessionId: "p2", name: "Bob", connected: true, totalScore: 0 },
+        ],
+      }),
+    ]);
+
+    await expectThrows(
+      () => mutators.reveal({
+        args: { gameId: "game3" },
+        tx,
+        ctx: serverCtx("p1"),
+      }),
+      "Only host can do that"
+    );
+  });
 });
 
 // ───────────────────────────────────────────────────────────

--- a/packages/shared/src/drizzle/schema.ts
+++ b/packages/shared/src/drizzle/schema.ts
@@ -410,6 +410,52 @@ export const pipsScores = pgTable(
   })
 );
 
+export const imposterPublicGames = pgTable(
+  "imposter_public_games",
+  {
+    id: text("id").primaryKey(),
+    code: text("code").notNull(),
+    hostId: text("host_id").notNull(),
+    phase: imposterPhaseEnum("phase").notNull().default("lobby"),
+    category: text("category"),
+    secretWord: text("secret_word"),
+    players: jsonb("players").$type<Array<{ sessionId: string; name: string | null; connected: boolean; role?: "imposter" | "player"; eliminated?: boolean }>>().notNull().default([]),
+    clues: jsonb("clues").$type<Array<{ sessionId: string; text: string; createdAt: number }>>().notNull().default([]),
+    votes: jsonb("votes").$type<Array<{ voterId: string; targetId: string }>>().notNull().default([]),
+    spectators: jsonb("spectators").$type<Array<{ sessionId: string; name: string | null }>>().notNull().default([]),
+    kicked: jsonb("kicked").$type<string[]>().notNull().default([]),
+    roundHistory: jsonb("round_history").$type<Array<{
+      round: number;
+      secretWord: string | null;
+      votedOutId: string | null;
+      votedOutName: string | null;
+      wasImposter: boolean;
+      clues: Array<{ sessionId: string; text: string }>;
+      votes: Array<{ voterId: string; targetId: string }>;
+    }>>().notNull().default([]),
+    announcement: jsonb("announcement").$type<{ text: string; ts: number } | null>().default(null),
+    settings: jsonb("settings").$type<{
+      rounds: number;
+      imposters: number;
+      currentRound: number;
+      roundDurationSec: number;
+      votingDurationSec: number;
+      phaseEndsAt: number | null;
+      skipVotes?: string[];
+    }>().notNull().default({
+      rounds: 3,
+      imposters: 1,
+      currentRound: 1,
+      roundDurationSec: 75,
+      votingDurationSec: 45,
+      phaseEndsAt: null
+    }),
+    isPublic: boolean("is_public").notNull().default(false),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    updatedAt: bigint("updated_at", { mode: "number" }).notNull()
+  }
+);
+
 export const pipsBannedSessions = pgTable(
   "pips_banned_sessions",
   {
@@ -424,6 +470,7 @@ export type DrizzleSchema = {
   sessions: typeof sessions;
   statusTable: typeof statusTable;
   imposterGames: typeof imposterGames;
+  imposterPublicGames: typeof imposterPublicGames;
   passwordGames: typeof passwordGames;
   chatMessages: typeof chatMessages;
   chainReactionGames: typeof chainReactionGames;

--- a/packages/shared/src/zero/mutators/chat.ts
+++ b/packages/shared/src/zero/mutators/chat.ts
@@ -1,7 +1,104 @@
 import { defineMutator } from "@rocicorp/zero";
 import { z } from "zod";
 import { zql } from "../schema";
-import { assertCaller, now, sanitizeText, resolvePlayerName } from "./helpers";
+import { assertCaller, assertHostUser, now, sanitizeText, resolvePlayerName } from "./helpers";
+
+type GameType = "imposter" | "password" | "chain_reaction" | "shade_signal" | "location_signal";
+
+type GameAudience = {
+  hostId: string;
+  participantIds: Set<string>;
+  imposterIds: Set<string>;
+};
+
+async function loadGameAudience(tx: { run: (...args: any[]) => Promise<any> }, gameType: GameType, gameId: string): Promise<GameAudience | null> {
+  if (gameType === "imposter") {
+    const game = await tx.run(zql.imposter_games.where("id", gameId).one()) as {
+      host_id: string;
+      players: Array<{ sessionId: string; role?: "imposter" | "player" }>;
+      spectators: Array<{ sessionId: string }>;
+    } | null;
+    if (!game) return null;
+    return {
+      hostId: game.host_id,
+      participantIds: new Set([
+        ...game.players.map((player) => player.sessionId),
+        ...game.spectators.map((spectator) => spectator.sessionId),
+      ]),
+      imposterIds: new Set(
+        game.players
+          .filter((player) => player.role === "imposter")
+          .map((player) => player.sessionId)
+      ),
+    };
+  }
+
+  if (gameType === "password") {
+    const game = await tx.run(zql.password_games.where("id", gameId).one()) as {
+      host_id: string;
+      teams: Array<{ members: string[] }>;
+      spectators: Array<{ sessionId: string }>;
+    } | null;
+    if (!game) return null;
+    return {
+      hostId: game.host_id,
+      participantIds: new Set([
+        ...game.teams.flatMap((team) => team.members),
+        ...game.spectators.map((spectator) => spectator.sessionId),
+      ]),
+      imposterIds: new Set(),
+    };
+  }
+
+  if (gameType === "chain_reaction") {
+    const game = await tx.run(zql.chain_reaction_games.where("id", gameId).one()) as {
+      host_id: string;
+      players: Array<{ sessionId: string }>;
+      spectators: Array<{ sessionId: string }>;
+    } | null;
+    if (!game) return null;
+    return {
+      hostId: game.host_id,
+      participantIds: new Set([
+        ...game.players.map((player) => player.sessionId),
+        ...game.spectators.map((spectator) => spectator.sessionId),
+      ]),
+      imposterIds: new Set(),
+    };
+  }
+
+  if (gameType === "shade_signal") {
+    const game = await tx.run(zql.shade_signal_games.where("id", gameId).one()) as {
+      host_id: string;
+      players: Array<{ sessionId: string }>;
+      spectators: Array<{ sessionId: string }>;
+    } | null;
+    if (!game) return null;
+    return {
+      hostId: game.host_id,
+      participantIds: new Set([
+        ...game.players.map((player) => player.sessionId),
+        ...game.spectators.map((spectator) => spectator.sessionId),
+      ]),
+      imposterIds: new Set(),
+    };
+  }
+
+  const game = await tx.run(zql.location_signal_games.where("id", gameId).one()) as {
+    host_id: string;
+    players: Array<{ sessionId: string }>;
+    spectators: Array<{ sessionId: string }>;
+  } | null;
+  if (!game) return null;
+  return {
+    hostId: game.host_id,
+    participantIds: new Set([
+      ...game.players.map((player) => player.sessionId),
+      ...game.spectators.map((spectator) => spectator.sessionId),
+    ]),
+    imposterIds: new Set(),
+  };
+}
 
 export const chatMutators = {
   send: defineMutator(
@@ -19,6 +116,20 @@ export const chatMutators = {
       assertCaller(tx, ctx, args.senderId);
       const cleanText = sanitizeText(args.text);
       if (!cleanText) throw new Error("Message cannot be empty");
+      const audience = await loadGameAudience(tx, args.gameType, args.gameId);
+      if (!audience) throw new Error("Game not found");
+      if (!audience.participantIds.has(args.senderId) && audience.hostId !== args.senderId) {
+        throw new Error("Only game members can chat");
+      }
+      const channel = args.channel ?? "all";
+      if (channel !== "all") {
+        if (args.gameType !== "imposter" || channel !== "imposter") {
+          throw new Error("Invalid chat channel");
+        }
+        if (!audience.imposterIds.has(args.senderId) || audience.imposterIds.size < 2) {
+          throw new Error("Only imposters can use this channel");
+        }
+      }
       const cleanName = resolvePlayerName(sanitizeText(args.senderName), args.senderId);
       await tx.mutate.chat_messages.insert({
         id: args.id,
@@ -27,7 +138,7 @@ export const chatMutators = {
         sender_id: args.senderId,
         sender_name: cleanName,
         badge: args.badge,
-        channel: args.channel ?? "all",
+        channel,
         text: cleanText,
         created_at: now()
       });
@@ -36,10 +147,13 @@ export const chatMutators = {
 
   clearForGame: defineMutator(
     z.object({ gameType: z.enum(["imposter", "password", "chain_reaction", "shade_signal", "location_signal"]), gameId: z.string() }),
-    async ({ args, tx }) => {
+    async ({ args, tx, ctx }) => {
+      const audience = await loadGameAudience(tx, args.gameType, args.gameId);
+      if (!audience) return;
+      assertHostUser(tx, ctx, audience.hostId);
       const msgs = await tx.run(
         zql.chat_messages.where("game_type", args.gameType).where("game_id", args.gameId)
-      );
+      ) as Array<{ id: string }>;
       for (const m of msgs) {
         await tx.mutate.chat_messages.delete({ id: m.id });
       }

--- a/packages/shared/src/zero/mutators/helpers.ts
+++ b/packages/shared/src/zero/mutators/helpers.ts
@@ -67,6 +67,11 @@ function shouldEnforceServerIdentity(tx: TxLike, ctx: ServerContext) {
   return tx.location === "server" && !!ctx.userId && ctx.userId !== "anon";
 }
 
+export function getServerUserId(ctx: unknown): string | null {
+  const safeCtx = asServerContext(ctx);
+  return typeof safeCtx.userId === "string" && safeCtx.userId !== "anon" ? safeCtx.userId : null;
+}
+
 export function assertCaller(tx: unknown, ctx: unknown, claimedId: string) {
   const safeTx = asTxLike(tx);
   const safeCtx = asServerContext(ctx);
@@ -85,6 +90,17 @@ export function assertHost(tx: unknown, ctx: unknown, claimedHostId: string, act
     return;
   }
   if (safeCtx.userId !== claimedHostId || claimedHostId !== actualHostId) {
+    throw new Error("Only host can do that");
+  }
+}
+
+export function assertHostUser(tx: unknown, ctx: unknown, actualHostId: string) {
+  const safeTx = asTxLike(tx);
+  const safeCtx = asServerContext(ctx);
+  if (!shouldEnforceServerIdentity(safeTx, safeCtx)) {
+    return;
+  }
+  if (safeCtx.userId !== actualHostId) {
     throw new Error("Only host can do that");
   }
 }

--- a/packages/shared/src/zero/mutators/imposter.ts
+++ b/packages/shared/src/zero/mutators/imposter.ts
@@ -1,8 +1,79 @@
 import { defineMutator } from "@rocicorp/zero";
 import { z } from "zod";
 import { zql } from "../schema";
-import { now, code, pickRandom, chooseRoles, assertCaller, assertHost, sanitizeText, resolvePlayerName } from "./helpers";
+import { encryptSecret } from "../../crypto";
+import { now, code, pickRandom, chooseRoles, assertCaller, assertHost, assertHostUser, getGameSecretResolver, isServerTx, sanitizeText, resolvePlayerName } from "./helpers";
 import { imposterWordBank } from "./word-banks";
+
+async function maybeEncryptImposterWord(ctx: unknown, gameId: string, word: string) {
+  const resolver = getGameSecretResolver(ctx);
+  if (!resolver) {
+    return word;
+  }
+  const key = await resolver("imposter", gameId);
+  return encryptSecret(word, key);
+}
+
+function redactImposterPlayers(
+  phase: "lobby" | "playing" | "voting" | "results" | "finished" | "ended",
+  players: Array<{ sessionId: string; name: string | null; connected: boolean; role?: "imposter" | "player"; eliminated?: boolean }>
+) {
+  if (phase === "results" || phase === "finished" || phase === "ended") {
+    return players;
+  }
+  return players.map(({ role: _role, ...player }) => player);
+}
+
+function redactImposterRoundHistory(
+  phase: "lobby" | "playing" | "voting" | "results" | "finished" | "ended",
+  roundHistory: Array<{
+    round: number;
+    secretWord: string | null;
+    votedOutId: string | null;
+    votedOutName: string | null;
+    wasImposter: boolean;
+    clues: Array<{ sessionId: string; text: string }>;
+    votes: Array<{ voterId: string; targetId: string }>;
+  }>
+) {
+  if (phase === "results" || phase === "finished" || phase === "ended") {
+    return roundHistory;
+  }
+  return roundHistory.map((entry) => ({ ...entry, secretWord: null }));
+}
+
+async function syncImposterPublicGame(tx: any, gameId: string) {
+  const game = await tx.run(zql.imposter_games.where("id", gameId).one());
+  if (!game) {
+    await tx.mutate.imposter_public_games.delete({ id: gameId });
+    return;
+  }
+
+  const publicSecretWord =
+    game.phase === "results" || game.phase === "finished" || game.phase === "ended"
+      ? game.secret_word ?? null
+      : (game.secret_word?.startsWith("enc:") ? game.secret_word : null);
+
+  await tx.mutate.imposter_public_games.upsert({
+    id: game.id,
+    code: game.code,
+    host_id: game.host_id,
+    phase: game.phase,
+    category: game.category,
+    secret_word: publicSecretWord,
+    players: redactImposterPlayers(game.phase, game.players),
+    clues: game.clues,
+    votes: game.votes,
+    spectators: game.spectators,
+    kicked: game.kicked,
+    round_history: redactImposterRoundHistory(game.phase, game.round_history),
+    announcement: game.announcement,
+    settings: game.settings,
+    is_public: game.is_public,
+    created_at: game.created_at,
+    updated_at: game.updated_at,
+  });
+}
 
 export const imposterMutators = {
   create: defineMutator(
@@ -51,6 +122,7 @@ export const imposterMutators = {
         created_at: ts,
         last_seen: ts
       });
+      await syncImposterPublicGame(tx, args.id);
     }
   ),
 
@@ -91,6 +163,7 @@ export const imposterMutators = {
             created_at: now(),
             last_seen: now()
           });
+          await syncImposterPublicGame(tx, game.id);
           return;
         }
         // Add as spectator instead of throwing
@@ -108,6 +181,7 @@ export const imposterMutators = {
           created_at: now(),
           last_seen: now()
         });
+        await syncImposterPublicGame(tx, game.id);
         return;
       }
 
@@ -133,6 +207,7 @@ export const imposterMutators = {
         created_at: now(),
         last_seen: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -162,6 +237,7 @@ export const imposterMutators = {
             last_seen: now()
           });
         }
+        await syncImposterPublicGame(tx, game.id);
         return;
       }
 
@@ -199,6 +275,7 @@ export const imposterMutators = {
         game_id: undefined,
         last_seen: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -215,11 +292,15 @@ export const imposterMutators = {
       const bank = imposterWordBank[game.category ?? "animals"] ?? imposterWordBank.animals ?? ["Planet"];
       const withRoles = chooseRoles(players, game.settings.imposters);
       const phaseEndsAt = now() + game.settings.roundDurationSec * 1000;
+      const secretWord = pickRandom(bank);
+      const nextSecretWord = isServerTx(tx)
+        ? await maybeEncryptImposterWord(ctx, args.gameId, secretWord)
+        : secretWord;
 
       await tx.mutate.imposter_games.update({
         id: game.id,
         phase: "playing",
-        secret_word: pickRandom(bank),
+        secret_word: nextSecretWord,
         players: withRoles.map((p) => ({ ...p, eliminated: false })),
         clues: [],
         votes: [],
@@ -227,6 +308,7 @@ export const imposterMutators = {
         settings: { ...game.settings, currentRound: 1, phaseEndsAt },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -259,6 +341,7 @@ export const imposterMutators = {
           : game.settings,
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -288,14 +371,16 @@ export const imposterMutators = {
         settings: allVoted ? { ...game.settings, phaseEndsAt: now() + 8000, skipVotes: [] } : game.settings,
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
   advanceTimer: defineMutator(
     z.object({ gameId: z.string() }),
-    async ({ args, tx }) => {
+    async ({ args, tx, ctx }) => {
       const game = await tx.run(zql.imposter_games.where("id", args.gameId).one());
       if (!game) return;
+      assertHostUser(tx, ctx, game.host_id);
 
       const phaseEnd = game.settings.phaseEndsAt;
       if (!phaseEnd || now() < phaseEnd) return; // not expired yet
@@ -317,6 +402,7 @@ export const imposterMutators = {
           settings: { ...game.settings, phaseEndsAt: now() + game.settings.votingDurationSec * 1000 },
           updated_at: now()
         });
+        await syncImposterPublicGame(tx, game.id);
       } else if (game.phase === "voting") {
         // Move to results with whatever votes exist; start results countdown
         await tx.mutate.imposter_games.update({
@@ -325,6 +411,7 @@ export const imposterMutators = {
           settings: { ...game.settings, phaseEndsAt: now() + 8000, skipVotes: [] },
           updated_at: now()
         });
+        await syncImposterPublicGame(tx, game.id);
       } else if (game.phase === "results") {
         // Tally votes → eliminate most-voted → check win conditions
         const activePlayers = game.players.filter((p) => !p.eliminated);
@@ -387,16 +474,18 @@ export const imposterMutators = {
             settings: { ...game.settings, phaseEndsAt: null },
             updated_at: now()
           });
+          await syncImposterPublicGame(tx, game.id);
           return;
         }
 
         // Continue to next round — new word, same roles, minus eliminated
         const bank = imposterWordBank[game.category ?? "animals"] ?? imposterWordBank.animals ?? ["Planet"];
         const phaseEndsAt = now() + game.settings.roundDurationSec * 1000;
+        const secretWord = pickRandom(bank);
         await tx.mutate.imposter_games.update({
           id: game.id,
           phase: "playing",
-          secret_word: pickRandom(bank),
+          secret_word: isServerTx(tx) ? await maybeEncryptImposterWord(ctx, args.gameId, secretWord) : secretWord,
           clues: [],
           votes: [],
           players: updatedPlayers,
@@ -405,6 +494,7 @@ export const imposterMutators = {
           settings: { ...game.settings, currentRound: nextRound, phaseEndsAt },
           updated_at: now()
         });
+        await syncImposterPublicGame(tx, game.id);
       }
     }
   ),
@@ -474,16 +564,18 @@ export const imposterMutators = {
           settings: { ...game.settings, phaseEndsAt: null },
           updated_at: now()
         });
+        await syncImposterPublicGame(tx, game.id);
         return;
       }
 
       // Continue to next round — new word, same roles, minus eliminated
       const bank = imposterWordBank[game.category ?? "animals"] ?? imposterWordBank.animals ?? ["Planet"];
       const phaseEndsAt = now() + game.settings.roundDurationSec * 1000;
+      const secretWord = pickRandom(bank);
       await tx.mutate.imposter_games.update({
         id: game.id,
         phase: "playing",
-        secret_word: pickRandom(bank),
+        secret_word: isServerTx(tx) ? await maybeEncryptImposterWord(ctx, args.gameId, secretWord) : secretWord,
         clues: [],
         votes: [],
         players: updatedPlayers,
@@ -492,6 +584,7 @@ export const imposterMutators = {
         settings: { ...game.settings, currentRound: nextRound, phaseEndsAt },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -518,6 +611,7 @@ export const imposterMutators = {
         settings: { ...game.settings, currentRound: 1, phaseEndsAt: null },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
 
       // Clear chat messages
       const msgs = await tx.run(
@@ -542,6 +636,7 @@ export const imposterMutators = {
         announcement: { text: cleanText, ts: now() },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -562,6 +657,7 @@ export const imposterMutators = {
         kicked,
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
 
       await tx.mutate.sessions.update({
         id: args.targetId,
@@ -585,6 +681,7 @@ export const imposterMutators = {
         settings: { ...game.settings, phaseEndsAt: null },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
 
       const gameSessions = await tx.run(
         zql.sessions.where("game_type", "imposter").where("game_id", game.id)
@@ -636,6 +733,7 @@ export const imposterMutators = {
         created_at: now(),
         last_seen: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -656,6 +754,7 @@ export const imposterMutators = {
         game_id: undefined,
         last_seen: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -677,6 +776,7 @@ export const imposterMutators = {
         game_id: undefined,
         last_seen: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -707,6 +807,7 @@ export const imposterMutators = {
         },
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   ),
 
@@ -722,6 +823,7 @@ export const imposterMutators = {
         is_public: args.isPublic,
         updated_at: now()
       });
+      await syncImposterPublicGame(tx, game.id);
     }
   )
 };

--- a/packages/shared/src/zero/mutators/location-signal.ts
+++ b/packages/shared/src/zero/mutators/location-signal.ts
@@ -1,7 +1,8 @@
 import { defineMutator } from "@rocicorp/zero";
 import { z } from "zod";
 import { zql } from "../schema";
-import { code, now, shuffle, assertCaller, assertHost, sanitizeText, resolvePlayerName } from "./helpers";
+import { decryptSecret, encryptSecret, isEncrypted } from "../../crypto";
+import { code, now, shuffle, assertCaller, assertHost, assertHostUser, getGameSecretResolver, isServerTx, sanitizeText, resolvePlayerName } from "./helpers";
 
 function toRadians(deg: number) {
   return (deg * Math.PI) / 180;
@@ -24,6 +25,43 @@ function scoreForDistance(km: number): number {
   if (km <= PERFECT_KM) return 5000;
   // Generous exponential decay: ~2500 at ~2000km, still scoring at 5000km+
   return Math.max(0, Math.round(5000 * Math.exp(-(km - PERFECT_KM) / 3000)));
+}
+
+async function encryptLocationTarget(ctx: unknown, gameId: string, target: { lat: number; lng: number }) {
+  const resolver = getGameSecretResolver(ctx);
+  if (!resolver) {
+    return { targetLat: target.lat, targetLng: target.lng, encryptedTarget: null as string | null };
+  }
+  const key = await resolver("location_signal", gameId);
+  return {
+    targetLat: null as number | null,
+    targetLng: null as number | null,
+    encryptedTarget: await encryptSecret(JSON.stringify(target), key),
+  };
+}
+
+async function resolveLocationTarget(
+  ctx: unknown,
+  gameId: string,
+  game: { target_lat?: number | null; target_lng?: number | null; encrypted_target?: string | null }
+) {
+  if (typeof game.target_lat === "number" && typeof game.target_lng === "number") {
+    return { lat: game.target_lat, lng: game.target_lng };
+  }
+  if (!game.encrypted_target || !isEncrypted(game.encrypted_target)) {
+    return null;
+  }
+  const resolver = getGameSecretResolver(ctx);
+  if (!resolver) {
+    return null;
+  }
+  const key = await resolver("location_signal", gameId);
+  const decrypted = await decryptSecret(game.encrypted_target, key);
+  const parsed = JSON.parse(decrypted) as { lat?: unknown; lng?: unknown };
+  if (typeof parsed.lat !== "number" || typeof parsed.lng !== "number") {
+    return null;
+  }
+  return { lat: parsed.lat, lng: parsed.lng };
 }
 
 export const locationSignalMutators = {
@@ -190,6 +228,7 @@ export const locationSignalMutators = {
         current_leader_index: 0,
         target_lat: null,
         target_lng: null,
+        encrypted_target: null,
         clue1: null,
         clue2: null,
         clue3: null,
@@ -210,12 +249,16 @@ export const locationSignalMutators = {
       if (!game) throw new Error("Game not found");
       if (game.phase !== "picking") throw new Error("Not in picking phase");
       if (game.leader_id !== args.sessionId) throw new Error("Only the leader can set target");
+      const nextTarget = isServerTx(tx)
+        ? await encryptLocationTarget(ctx, args.gameId, { lat: args.lat, lng: args.lng })
+        : { targetLat: args.lat, targetLng: args.lng, encryptedTarget: null as string | null };
 
       await tx.mutate.location_signal_games.update({
         id: game.id,
         phase: "clue1",
-        target_lat: args.lat,
-        target_lng: args.lng,
+        target_lat: nextTarget.targetLat,
+        target_lng: nextTarget.targetLng,
+        encrypted_target: nextTarget.encryptedTarget,
         settings: { ...game.settings, phaseEndsAt: ts + game.settings.clueDurationSec * 1000 },
         updated_at: ts,
       });
@@ -252,8 +295,13 @@ export const locationSignalMutators = {
       const ts = now();
       const game = await tx.run(zql.location_signal_games.where("id", args.gameId).one());
       if (!game) throw new Error("Game not found");
+      const expectedPhase = `guess${args.round}` as const;
+      if (game.phase !== expectedPhase) throw new Error("Not in the matching guess phase");
       if (!game.leader_id) throw new Error("No active leader");
       if (args.sessionId === game.leader_id) throw new Error("Leader cannot submit guesses");
+      if (!game.players.some((player) => player.sessionId === args.sessionId)) {
+        throw new Error("Only players in the game can guess");
+      }
 
       const withoutExisting = game.guesses.filter((g) => !(g.sessionId === args.sessionId && g.round === args.round));
       const guesses = [...withoutExisting, { sessionId: args.sessionId, round: args.round, lat: args.lat, lng: args.lng }];
@@ -261,8 +309,9 @@ export const locationSignalMutators = {
       // Duel perfect-score shortcut: if there's exactly 1 guesser and they nailed it, skip to reveal
       const guessersCount = game.players.filter((p) => p.sessionId !== game.leader_id).length;
       const isDuel = guessersCount === 1;
-      if (isDuel && game.target_lat != null && game.target_lng != null) {
-        const km = haversineKm(game.target_lat, game.target_lng, args.lat, args.lng);
+      const target = await resolveLocationTarget(ctx, args.gameId, game);
+      if (isDuel && target) {
+        const km = haversineKm(target.lat, target.lng, args.lat, args.lng);
         if (km <= PERFECT_KM) {
           const scores = game.players.reduce<Record<string, number>>((acc, p) => {
             acc[p.sessionId] = p.totalScore;
@@ -280,7 +329,7 @@ export const locationSignalMutators = {
             {
               round: game.settings.currentRound,
               leaderId: game.leader_id,
-              target: { lat: game.target_lat, lng: game.target_lng },
+              target,
               clue1: game.clue1, clue2: game.clue2, clue3: game.clue3, clue4: game.clue4,
               guesses,
               scores,
@@ -291,6 +340,9 @@ export const locationSignalMutators = {
             id: game.id,
             guesses,
             phase: "reveal",
+            target_lat: target.lat,
+            target_lng: target.lng,
+            encrypted_target: null,
             players,
             round_history: nextHistory,
             settings: { ...game.settings, phaseEndsAt: null },
@@ -328,7 +380,8 @@ export const locationSignalMutators = {
       const game = await tx.run(zql.location_signal_games.where("id", args.gameId).one());
       if (!game) throw new Error("Game not found");
       if (game.host_id !== args.hostId) throw new Error("Only host can advance");
-      if (game.target_lat === null || game.target_lng === null || !game.leader_id) throw new Error("Round target is missing");
+      const target = await resolveLocationTarget(ctx, args.gameId, game);
+      if (!target || !game.leader_id) throw new Error("Round target is missing");
 
       const cluePairs = game.settings.cluePairs ?? 2;
 
@@ -369,7 +422,7 @@ export const locationSignalMutators = {
         if (player.sessionId === game.leader_id) continue;
         const guess = bestGuesses.get(player.sessionId);
         if (!guess) continue;
-        const km = haversineKm(game.target_lat, game.target_lng, guess.lat, guess.lng);
+        const km = haversineKm(target.lat, target.lng, guess.lat, guess.lng);
         scores[player.sessionId] = (scores[player.sessionId] ?? 0) + scoreForDistance(km);
       }
 
@@ -383,7 +436,7 @@ export const locationSignalMutators = {
         {
           round: game.settings.currentRound,
           leaderId: game.leader_id,
-          target: { lat: game.target_lat, lng: game.target_lng },
+          target,
           clue1: game.clue1,
           clue2: game.clue2,
           clue3: game.clue3,
@@ -396,6 +449,9 @@ export const locationSignalMutators = {
       await tx.mutate.location_signal_games.update({
         id: game.id,
         phase: "reveal",
+        target_lat: target.lat,
+        target_lng: target.lng,
+        encrypted_target: null,
         players,
         round_history: nextHistory,
         settings: { ...game.settings, phaseEndsAt: null },
@@ -435,6 +491,7 @@ export const locationSignalMutators = {
         leader_id: nextLeaderId,
         target_lat: null,
         target_lng: null,
+        encrypted_target: null,
         clue1: null,
         clue2: null,
         clue3: null,
@@ -452,9 +509,10 @@ export const locationSignalMutators = {
 
   advanceTimer: defineMutator(
     z.object({ gameId: z.string() }),
-    async ({ args, tx }) => {
+    async ({ args, tx, ctx }) => {
       const game = await tx.run(zql.location_signal_games.where("id", args.gameId).one());
       if (!game) return;
+      assertHostUser(tx, ctx, game.host_id);
       const phaseEnd = game.settings.phaseEndsAt;
       if (!phaseEnd || phaseEnd > now()) return;
 
@@ -484,7 +542,8 @@ export const locationSignalMutators = {
           });
         } else {
           // Last guess round — score and go to reveal
-          if (game.target_lat == null || game.target_lng == null || !game.leader_id) {
+          const target = await resolveLocationTarget(ctx, args.gameId, game);
+          if (!target || !game.leader_id) {
             // Missing target — skip to reveal anyway
             await tx.mutate.location_signal_games.update({
               id: game.id,
@@ -512,7 +571,7 @@ export const locationSignalMutators = {
             if (player.sessionId === game.leader_id) continue;
             const guess = bestGuesses.get(player.sessionId);
             if (!guess) continue;
-            const km = haversineKm(game.target_lat, game.target_lng, guess.lat, guess.lng);
+            const km = haversineKm(target.lat, target.lng, guess.lat, guess.lng);
             scores[player.sessionId] = (scores[player.sessionId] ?? 0) + scoreForDistance(km);
           }
 
@@ -526,7 +585,7 @@ export const locationSignalMutators = {
             {
               round: game.settings.currentRound,
               leaderId: game.leader_id,
-              target: { lat: game.target_lat, lng: game.target_lng },
+              target,
               clue1: game.clue1,
               clue2: game.clue2,
               clue3: game.clue3,
@@ -539,6 +598,9 @@ export const locationSignalMutators = {
           await tx.mutate.location_signal_games.update({
             id: game.id,
             phase: "reveal",
+            target_lat: target.lat,
+            target_lng: target.lng,
+            encrypted_target: null,
             players,
             round_history: nextHistory,
             settings: { ...game.settings, phaseEndsAt: now() + 10000 },
@@ -570,6 +632,7 @@ export const locationSignalMutators = {
           leader_id: nextLeaderId,
           target_lat: null,
           target_lng: null,
+          encrypted_target: null,
           clue1: null,
           clue2: null,
           clue3: null,
@@ -745,6 +808,7 @@ export const locationSignalMutators = {
         current_leader_index: 0,
         target_lat: null,
         target_lng: null,
+        encrypted_target: null,
         clue1: null,
         clue2: null,
         clue3: null,

--- a/packages/shared/src/zero/mutators/password.ts
+++ b/packages/shared/src/zero/mutators/password.ts
@@ -2,7 +2,7 @@ import { defineMutator } from "@rocicorp/zero";
 import { z } from "zod";
 import { zql } from "../schema";
 import { decryptSecret, encryptSecret, isEncrypted } from "../../crypto";
-import { getGameSecretResolver, isServerTx, now, code, normalized, isClueTooSimilar, pickPasswordWord, buildTeamRound, buildAllTeamRounds, assertCaller, assertHost, sanitizeText, resolvePlayerName } from "./helpers";
+import { getGameSecretResolver, isServerTx, now, code, normalized, isClueTooSimilar, pickPasswordWord, buildTeamRound, buildAllTeamRounds, assertCaller, assertHost, assertHostUser, sanitizeText, resolvePlayerName } from "./helpers";
 
 async function maybeEncryptPasswordWord(ctx: unknown, gameId: string, word: string | null) {
   if (!word) {
@@ -466,6 +466,7 @@ export const passwordMutators = {
     async ({ args, tx, ctx }) => {
       const game = await tx.run(zql.password_games.where("id", args.gameId).one());
       if (!game || game.phase !== "playing" || !game.active_rounds.length) return;
+      assertHostUser(tx, ctx, game.host_id);
       const roundEndsAt = game.settings.roundEndsAt;
       if (!roundEndsAt || now() < roundEndsAt) return; // not expired
 

--- a/packages/shared/src/zero/mutators/shade-signal.ts
+++ b/packages/shared/src/zero/mutators/shade-signal.ts
@@ -1,7 +1,45 @@
 import { defineMutator } from "@rocicorp/zero";
 import { z } from "zod";
 import { zql } from "../schema";
-import { now, code, shuffle, assertCaller, assertHost, sanitizeText, resolvePlayerName } from "./helpers";
+import { decryptSecret, encryptSecret, isEncrypted } from "../../crypto";
+import { now, code, shuffle, assertCaller, assertHost, assertHostUser, getGameSecretResolver, isServerTx, sanitizeText, resolvePlayerName } from "./helpers";
+
+async function encryptShadeTarget(ctx: unknown, gameId: string, target: { row: number; col: number }) {
+  const resolver = getGameSecretResolver(ctx);
+  if (!resolver) {
+    return { targetRow: target.row, targetCol: target.col, encryptedTarget: null as string | null };
+  }
+  const key = await resolver("shade_signal", gameId);
+  return {
+    targetRow: null as number | null,
+    targetCol: null as number | null,
+    encryptedTarget: await encryptSecret(JSON.stringify(target), key),
+  };
+}
+
+async function resolveShadeTarget(
+  ctx: unknown,
+  gameId: string,
+  game: { target_row?: number | null; target_col?: number | null; encrypted_target?: string | null }
+) {
+  if (typeof game.target_row === "number" && typeof game.target_col === "number") {
+    return { row: game.target_row, col: game.target_col };
+  }
+  if (!game.encrypted_target || !isEncrypted(game.encrypted_target)) {
+    return null;
+  }
+  const resolver = getGameSecretResolver(ctx);
+  if (!resolver) {
+    return null;
+  }
+  const key = await resolver("shade_signal", gameId);
+  const decrypted = await decryptSecret(game.encrypted_target, key);
+  const parsed = JSON.parse(decrypted) as { row?: unknown; col?: unknown };
+  if (typeof parsed.row !== "number" || typeof parsed.col !== "number") {
+    return null;
+  }
+  return { row: parsed.row, col: parsed.col };
+}
 
 export const shadeSignalMutators = {
   create: defineMutator(
@@ -249,8 +287,14 @@ export const shadeSignalMutators = {
       const rows = game.grid_rows;
       const cols = game.grid_cols;
       const leaderPick = game.settings.leaderPick ?? false;
-      const targetRow = leaderPick ? null : Math.floor(Math.random() * rows);
-      const targetCol = leaderPick ? null : Math.floor(Math.random() * cols);
+      const autoTarget = leaderPick ? null : { row: Math.floor(Math.random() * rows), col: Math.floor(Math.random() * cols) };
+      const encryptedTarget = isServerTx(tx) && autoTarget
+        ? await encryptShadeTarget(ctx, args.gameId, autoTarget)
+        : {
+            targetRow: autoTarget?.row ?? null,
+            targetCol: autoTarget?.col ?? null,
+            encryptedTarget: null as string | null,
+          };
 
       await tx.mutate.shade_signal_games.update({
         id: game.id,
@@ -259,8 +303,9 @@ export const shadeSignalMutators = {
         leader_order: leaderOrder,
         current_leader_index: 0,
         grid_seed: Math.floor(Math.random() * 100000),
-        target_row: targetRow,
-        target_col: targetCol,
+        target_row: encryptedTarget.targetRow,
+        target_col: encryptedTarget.targetCol,
+        encrypted_target: encryptedTarget.encryptedTarget,
         clue1: null,
         clue2: null,
         guesses: [],
@@ -287,12 +332,16 @@ export const shadeSignalMutators = {
       if (!game) throw new Error("Game not found");
       if (game.phase !== "picking") throw new Error("Not in picking phase");
       if (game.leader_id !== args.sessionId) throw new Error("Only the leader can pick the target");
+      const nextTarget = isServerTx(tx)
+        ? await encryptShadeTarget(ctx, args.gameId, { row: args.row, col: args.col })
+        : { targetRow: args.row, targetCol: args.col, encryptedTarget: null as string | null };
 
       await tx.mutate.shade_signal_games.update({
         id: game.id,
         phase: "clue1",
-        target_row: args.row,
-        target_col: args.col,
+        target_row: nextTarget.targetRow,
+        target_col: nextTarget.targetCol,
+        encrypted_target: nextTarget.encryptedTarget,
         settings: {
           ...game.settings,
           phaseEndsAt: now() + game.settings.clueDurationSec * 1000
@@ -414,9 +463,10 @@ export const shadeSignalMutators = {
 
   advanceTimer: defineMutator(
     z.object({ gameId: z.string() }),
-    async ({ args, tx }) => {
+    async ({ args, tx, ctx }) => {
       const game = await tx.run(zql.shade_signal_games.where("id", args.gameId).one());
       if (!game) return;
+      assertHostUser(tx, ctx, game.host_id);
       const phaseEnd = game.settings.phaseEndsAt;
       if (!phaseEnd || phaseEnd > now()) return;
 
@@ -472,6 +522,14 @@ export const shadeSignalMutators = {
         const rows = game.grid_rows;
         const cols = game.grid_cols;
         const leaderPick = game.settings.leaderPick ?? false;
+        const autoTarget = leaderPick ? null : { row: Math.floor(Math.random() * rows), col: Math.floor(Math.random() * cols) };
+        const encryptedTarget = isServerTx(tx) && autoTarget
+          ? await encryptShadeTarget(ctx, args.gameId, autoTarget)
+          : {
+              targetRow: autoTarget?.row ?? null,
+              targetCol: autoTarget?.col ?? null,
+              encryptedTarget: null as string | null,
+            };
 
         await tx.mutate.shade_signal_games.update({
           id: game.id,
@@ -479,8 +537,9 @@ export const shadeSignalMutators = {
           leader_id: nextLeaderId,
           current_leader_index: nextLeaderIndex,
           grid_seed: Math.floor(Math.random() * 100000),
-          target_row: leaderPick ? null : Math.floor(Math.random() * rows),
-          target_col: leaderPick ? null : Math.floor(Math.random() * cols),
+          target_row: encryptedTarget.targetRow,
+          target_col: encryptedTarget.targetCol,
+          encrypted_target: encryptedTarget.encryptedTarget,
           clue1: null,
           clue2: null,
           guesses: [],
@@ -497,13 +556,15 @@ export const shadeSignalMutators = {
 
   reveal: defineMutator(
     z.object({ gameId: z.string() }),
-    async ({ args, tx }) => {
+    async ({ args, tx, ctx }) => {
       const game = await tx.run(zql.shade_signal_games.where("id", args.gameId).one());
       if (!game) throw new Error("Game not found");
+      assertHostUser(tx, ctx, game.host_id);
       if (game.phase !== "reveal") throw new Error("Not in reveal phase");
-
-      const targetRow = game.target_row ?? 0;
-      const targetCol = game.target_col ?? 0;
+      const resolvedTarget = await resolveShadeTarget(ctx, args.gameId, game);
+      if (!resolvedTarget) throw new Error("Target is missing");
+      const targetRow = resolvedTarget.row;
+      const targetCol = resolvedTarget.col;
 
       // Score each guesser's best guess (use final guess if exists, else guess1)
       const guesserIds = game.players
@@ -558,6 +619,9 @@ export const shadeSignalMutators = {
 
       await tx.mutate.shade_signal_games.update({
         id: game.id,
+        target_row: targetRow,
+        target_col: targetCol,
+        encrypted_target: null,
         players,
         round_history: [...game.round_history, roundEntry],
         settings: { ...game.settings, phaseEndsAt: now() + 8000 },
@@ -595,6 +659,14 @@ export const shadeSignalMutators = {
       const rows = game.grid_rows;
       const cols = game.grid_cols;
       const leaderPick = game.settings.leaderPick ?? false;
+      const autoTarget = leaderPick ? null : { row: Math.floor(Math.random() * rows), col: Math.floor(Math.random() * cols) };
+      const encryptedTarget = isServerTx(tx) && autoTarget
+        ? await encryptShadeTarget(ctx, args.gameId, autoTarget)
+        : {
+            targetRow: autoTarget?.row ?? null,
+            targetCol: autoTarget?.col ?? null,
+            encryptedTarget: null as string | null,
+          };
 
       await tx.mutate.shade_signal_games.update({
         id: game.id,
@@ -602,8 +674,9 @@ export const shadeSignalMutators = {
         leader_id: nextLeaderId,
         current_leader_index: nextLeaderIndex,
         grid_seed: Math.floor(Math.random() * 100000),
-        target_row: leaderPick ? null : Math.floor(Math.random() * rows),
-        target_col: leaderPick ? null : Math.floor(Math.random() * cols),
+        target_row: encryptedTarget.targetRow,
+        target_col: encryptedTarget.targetCol,
+        encrypted_target: encryptedTarget.encryptedTarget,
         clue1: null,
         clue2: null,
         guesses: [],
@@ -635,6 +708,7 @@ export const shadeSignalMutators = {
         current_leader_index: 0,
         target_row: null,
         target_col: null,
+        encrypted_target: null,
         clue1: null,
         clue2: null,
         guesses: [],

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -20,15 +20,11 @@ export const queries = defineQueries({
   imposter: {
     byId: defineQuery(
       z.object({ id: z.string() }),
-      ({ args }) => zql.imposter_games.where("id", args.id).limit(1)
+      ({ args }) => zql.imposter_public_games.where("id", args.id).limit(1)
     ),
     byCode: defineQuery(
       z.object({ code: z.string() }),
-      ({ args }) => zql.imposter_games.where("code", args.code).limit(1)
-    ),
-    publicGames: defineQuery(
-      z.object({}),
-      () => zql.imposter_games.where("is_public", true).where("phase", "!=", "ended")
+      ({ args }) => zql.imposter_public_games.where("code", args.code).limit(1)
     )
   },
   password: {
@@ -39,10 +35,6 @@ export const queries = defineQueries({
     byCode: defineQuery(
       z.object({ code: z.string() }),
       ({ args }) => zql.password_games.where("code", args.code).limit(1)
-    ),
-    publicGames: defineQuery(
-      z.object({}),
-      () => zql.password_games.where("is_public", true).where("phase", "!=", "ended")
     )
   },
   chainReaction: {
@@ -53,10 +45,6 @@ export const queries = defineQueries({
     byCode: defineQuery(
       z.object({ code: z.string() }),
       ({ args }) => zql.chain_reaction_games.where("code", args.code).limit(1)
-    ),
-    publicGames: defineQuery(
-      z.object({}),
-      () => zql.chain_reaction_games.where("is_public", true).where("phase", "!=", "ended").where("phase", "!=", "finished")
     )
   },
   shadeSignal: {
@@ -67,10 +55,6 @@ export const queries = defineQueries({
     byCode: defineQuery(
       z.object({ code: z.string() }),
       ({ args }) => zql.shade_signal_games.where("code", args.code).limit(1)
-    ),
-    publicGames: defineQuery(
-      z.object({}),
-      () => zql.shade_signal_games.where("is_public", true).where("phase", "!=", "ended")
     )
   },
   locationSignal: {
@@ -81,10 +65,6 @@ export const queries = defineQueries({
     byCode: defineQuery(
       z.object({ code: z.string() }),
       ({ args }) => zql.location_signal_games.where("code", args.code).limit(1)
-    ),
-    publicGames: defineQuery(
-      z.object({}),
-      () => zql.location_signal_games.where("is_public", true).where("phase", "!=", "ended")
     )
   },
   chat: {
@@ -94,6 +74,16 @@ export const queries = defineQueries({
         zql.chat_messages
           .where("game_type", args.gameType)
           .where("game_id", args.gameId)
+          .where("channel", "all")
+          .orderBy("created_at", "asc")
+    ),
+    imposterByGame: defineQuery(
+      z.object({ gameId: z.string() }),
+      ({ args }) =>
+        zql.chat_messages
+          .where("game_type", "imposter")
+          .where("game_id", args.gameId)
+          .where("channel", "imposter")
           .orderBy("created_at", "asc")
     )
   }

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -55,6 +55,42 @@ const imposterGames = table("imposter_games").columns({
   updated_at: number()
 }).primaryKey("id");
 
+const imposterPublicGames = table("imposter_public_games").columns({
+  id: string(),
+  code: string(),
+  host_id: string(),
+  phase: enumeration<"lobby" | "playing" | "voting" | "results" | "finished" | "ended">(),
+  category: string().optional(),
+  secret_word: string().optional(),
+  players: json<Array<{ sessionId: string; name: string | null; connected: boolean; role?: "imposter" | "player"; eliminated?: boolean }>>(),
+  clues: json<Array<{ sessionId: string; text: string; createdAt: number }>>(),
+  votes: json<Array<{ voterId: string; targetId: string }>>(),
+  spectators: json<Array<{ sessionId: string; name: string | null }>>(),
+  kicked: json<string[]>(),
+  round_history: json<Array<{
+    round: number;
+    secretWord: string | null;
+    votedOutId: string | null;
+    votedOutName: string | null;
+    wasImposter: boolean;
+    clues: Array<{ sessionId: string; text: string }>;
+    votes: Array<{ voterId: string; targetId: string }>;
+  }>>(),
+  announcement: json<{ text: string; ts: number } | null>(),
+  settings: json<{
+    rounds: number;
+    imposters: number;
+    currentRound: number;
+    roundDurationSec: number;
+    votingDurationSec: number;
+    phaseEndsAt: number | null;
+    skipVotes?: string[];
+  }>(),
+  is_public: boolean(),
+  created_at: number(),
+  updated_at: number()
+}).primaryKey("id");
+
 const passwordGames = table("password_games").columns({
   id: string(),
   code: string(),
@@ -243,7 +279,16 @@ const sessionRelationships = relationships(sessions, ({ one }) => ({
 }));
 
 export const schema = createSchema({
-  tables: [sessions, imposterGames, passwordGames, chatMessages, chainReactionGames, shadeSignalGames, locationSignalGames],
+  tables: [
+    sessions,
+    imposterGames,
+    imposterPublicGames,
+    passwordGames,
+    chatMessages,
+    chainReactionGames,
+    shadeSignalGames,
+    locationSignalGames
+  ],
   relationships: [sessionRelationships]
 });
 

--- a/scripts/db-push-prod.ps1
+++ b/scripts/db-push-prod.ps1
@@ -42,11 +42,11 @@ Write-Host "Pushing schema to production..." -ForegroundColor Cyan
 $env:DATABASE_URL = $PROD_DB_URL
 Push-Location (Join-Path $ROOT_DIR "packages\shared")
 try {
-    npx drizzle-kit push
+    bun run db:push
 } finally {
     Pop-Location
     Remove-Item Env:\DATABASE_URL
 }
 
 Write-Host ""
-Write-Host "Done! Schema pushed to production." -ForegroundColor Green
+Write-Host "Done! Schema and Zero views pushed to production." -ForegroundColor Green

--- a/scripts/db-push-prod.sh
+++ b/scripts/db-push-prod.sh
@@ -34,6 +34,6 @@ fi
 echo ""
 echo "Pushing schema to production..."
 cd "$ROOT_DIR/packages/shared"
-DATABASE_URL="$PROD_DB_URL" npx drizzle-kit push
+DATABASE_URL="$PROD_DB_URL" bun run db:push
 echo ""
-echo "Done! Schema pushed to production."
+echo "Done! Schema and Zero views pushed to production."


### PR DESCRIPTION
## What does this PR do?

P0: signed session proof is now required on sensitive API routes and Zero mutations, production secrets fail closed, forwarded headers are only trusted in trusted-proxy mode, rate limiting now fails closed, and CORS/Pusher/admin auth are tightened.
P1: public game browsing now uses summary-only views, unknown Zero queries are denied, Imposter live state is redacted through a public view, private Imposter chat is split out of the shared feed, and role/secret access now flows through /api/game-secret/key.
P2: timer/reveal/chat/guess mutators are hardened with explicit host/member checks, admin proxy traversal is blocked, GitHub admin allowlisting uses immutable provider IDs, and the old /api/game-secret/pre-reveal path is gone because reveal decryption now happens server-side.

- [x] TypeScript compiles (`bun typecheck`)
- [x] Tested locally in browser
- [x] Schema changes pushed (if applicable)
- [x] No console errors or warnings added
- [x] Docs updated (if adding a new game)
- [x] Mobile UI tested (if touching `apps/web/src/mobile/`)
- [x] Desktop UI unaffected (if touching shared components)


## Additional notes

Full security overhaul!
