### PR TITLE
fix: reject joins to ended/finished Location Signal games

### DIFF
--- a/packages/shared/src/zero/mutators/location-signal.ts
+++ b/packages/shared/src/zero/mutators/location-signal.ts
@@ -91,6 +91,7 @@ export const locationSignalMutators = {
       const sessionName = resolvePlayerName(session?.name, args.sessionId);
       const game = await tx.run(zql.location_signal_games.where("id", args.gameId).one());
       if (!game) throw new Error("Game not found");
+      if (game.phase === "ended" || game.phase === "finished") throw new Error("Game has ended");
       if (game.kicked.includes(args.sessionId)) throw new Error("You have been kicked from this game");
       const existing = game.players.find((p) => p.sessionId === args.sessionId);
 


### PR DESCRIPTION
## What does this PR do?

Adds the `"Game has ended"` guard to the Location Signal `join` mutator so attempts to join an **ended** or **finished** game are rejected — matching behavior already present in the other four game types (Imposter, Password, Chain Reaction, Shade Signal).

Previously, Location Signal was the only game whose `join` mutator lacked this guard. Because `phase !== "lobby"` is true for ended/finished games, a joiner was silently added to `spectators` instead of being rejected. This makes the five games consistent.

Intended join behavior is unchanged and preserved:
- Joining a **lobby** -> join as a player
- Joining an **in-progress** game -> added as a spectator
- Joining an **ended/finished** game -> rejected (this is the fix)

The mutator runs on both client and server; the **server enforces the guard immediately**, so there is no exploit window even before clients reload the updated bundle.

## Game affected

- [x] Platform / shared (affects **Location Signal** via shared Zero mutators)

## Type of change

- [x] Bug fix

## Checklist

- [x] TypeScript compiles (`bun typecheck`)
- [x] No console errors or warnings added
- [x] Desktop UI unaffected (shared component / mutator only)

## Additional notes

Found during a security/anti-cheat audit of the join flow. The audit confirmed the desired spectator-on-join behavior is already implemented across all games; this one-line guard was the only inconsistency. No schema changes; no migration required.